### PR TITLE
Add Exa to the development shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -93,6 +93,7 @@
             ];
             nativeBuildInputs = [
               pkgs.binutils
+              pkgs.exa
               pkgs.openssl
               pkgs.postgresql
               pkgs.secp256k1


### PR DESCRIPTION
While not strictly required, exa is a nice replacement for ls, tree, and simple git status.