### PR TITLE
Modify flake to use eachDefaultSystem instead of explicit list

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,7 @@
       haskellPackages = prev.haskellPackages.extend haskell-overlay;
     };
   in
-    flake-utils.lib.eachSystem [flake-utils.lib.system.x86_64-linux] (
+    flake-utils.lib.eachDefaultSystem (
       system: let
         pkgs = import nixpkgs {
           inherit system;


### PR DESCRIPTION
We noticed while looking at the
[thyme](https://github.com/nuttycom/thyme/blob/nix_build/flake.nix#L25) flake that we could use eachDefaultSystem instead to drive builds for different architectures.