### PR TITLE
Upgrade the nixpkgs version to `release-23.05`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -8,23 +8,8 @@ source-repository-package
 
 source-repository-package
     type: git
-    location: https://github.com/nuttycom/thyme.git
-    tag: 14422f2dd5ba369cf68b1c42363dcb6f92860ccc
-
-source-repository-package
-    type: git
     location: https://github.com/nuttycom/snaplet-postgresql-simple.git
     tag: c314c6f64bc00d05dab9630f30f269740da6ea9e
-
-source-repository-package
-    type: git
-    location: https://github.com/nuttycom/secp256k1-haskell.git
-    tag: 610780ee4c0c74bb1b66169d863a47e5fb49211e
-
-source-repository-package
-    type: git
-    location: https://github.com/nuttycom/true-name.git
-    tag: 6ec32f4170a4bf823f6d80d1e3b6dc3e18746d87
 
 source-repository-package
     type: git

--- a/flake.lock
+++ b/flake.lock
@@ -192,36 +192,6 @@
         "type": "github"
       }
     },
-    "flake-utils_7": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_8": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1669597314,
@@ -299,48 +269,16 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1677447818,
-        "narHash": "sha256-dgXEUbz2hgaJL4xCD/5JLhA36UJOhP4qn7Cp6UZhB0I=",
+        "lastModified": 1688046951,
+        "narHash": "sha256-mZPRzl2gh/jfnukWTA9nOdkZ+UTlLXPXGlSOoeHjtbE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8bd260eb578e3fea6bce158b24c93ab158d031e7",
+        "rev": "3277aaf590524399a22fca5dfb41f08d25e27248",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-22.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_7": {
-      "locked": {
-        "lastModified": 1671391912,
-        "narHash": "sha256-W8sbJuN/i+OZdRuIzDiIyKOqVB/G26zh9DQL1rfp2xk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "09e8ac77744dd036e58ab2284e6f5c03a6d6ed41",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "release-22.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_8": {
-      "locked": {
-        "lastModified": 1672445539,
-        "narHash": "sha256-wb92a4hgDiLV1Zb9f+Pjd5ORmo3IxxI4AkJC/Ig6gqg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "52320d9779090d5f3427afca688b4246351c2b12",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "haskell-updates",
+        "ref": "release-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -351,49 +289,7 @@
         "dbmigrations-postgresql": "dbmigrations-postgresql",
         "dbmigrations-postgresql-simple": "dbmigrations-postgresql-simple",
         "flake-utils": "flake-utils_6",
-        "nixpkgs": "nixpkgs_6",
-        "thyme": "thyme"
-      }
-    },
-    "thyme": {
-      "inputs": {
-        "flake-utils": "flake-utils_7",
-        "nixpkgs": "nixpkgs_7",
-        "true-name": "true-name"
-      },
-      "locked": {
-        "lastModified": 1672449320,
-        "narHash": "sha256-PGuITPgJoeGtdl6fjg6s6G9MJeBOE+2qWQzcpXCiEdI=",
-        "owner": "nuttycom",
-        "repo": "thyme",
-        "rev": "14422f2dd5ba369cf68b1c42363dcb6f92860ccc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nuttycom",
-        "repo": "thyme",
-        "rev": "14422f2dd5ba369cf68b1c42363dcb6f92860ccc",
-        "type": "github"
-      }
-    },
-    "true-name": {
-      "inputs": {
-        "flake-utils": "flake-utils_8",
-        "nixpkgs": "nixpkgs_8"
-      },
-      "locked": {
-        "lastModified": 1672447106,
-        "narHash": "sha256-RJerQdGjz5mbslnzPgO+2v+G/9QOeaa155VKKAxyrVg=",
-        "owner": "nuttycom",
-        "repo": "true-name",
-        "rev": "6ec32f4170a4bf823f6d80d1e3b6dc3e18746d87",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nuttycom",
-        "repo": "true-name",
-        "rev": "6ec32f4170a4bf823f6d80d1e3b6dc3e18746d87",
-        "type": "github"
+        "nixpkgs": "nixpkgs_6"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,12 +2,11 @@
   description = "The Aftok Collaboration Server";
 
   inputs = {
-    nixpkgs.url = github:NixOS/nixpkgs/release-22.11;
+    nixpkgs.url = github:NixOS/nixpkgs/release-23.05;
     flake-utils.url = "github:numtide/flake-utils";
     dbmigrations.url = "github:nuttycom/dbmigrations/74ef9388b45ae73a1d9c737d9644e076fe832672";
     dbmigrations-postgresql.url = "github:nuttycom/dbmigrations-postgresql/3c9477e45e923b28d9677dc6291e35bb7c833c28";
     dbmigrations-postgresql-simple.url = "github:nuttycom/dbmigrations-postgresql-simple/d51bbc5a0b7d91f7c8a12fc28e5ecbe7ac326221";
-    thyme.url = "github:nuttycom/thyme/14422f2dd5ba369cf68b1c42363dcb6f92860ccc";
   };
 
   outputs = {
@@ -17,7 +16,6 @@
     dbmigrations,
     dbmigrations-postgresql,
     dbmigrations-postgresql-simple,
-    thyme,
   }: let
     overlay = final: prev: let
       jailbreakUnbreak = pkg:
@@ -52,6 +50,9 @@
         secp256k1 = final.secp256k1;
         secp256k1-haskell = hfinal.callCabal2nix "secp256k1-haskell" secp256k1-haskell-src {};
         haskoin-core = dontCheck (jailbreakUnbreak hprev.haskoin-core);
+        http-streams = dontCheck hprev.http-streams;
+        openssl-streams = dontCheck hprev.openssl-streams;
+        snap = dontCheck hprev.snap;
         bippy = dontCheck (hfinal.callCabal2nix "bippy" bippy-src {});
 
         HsOpenSSL = hfinal.callCabal2nix "HsOpenSSL" HsOpenSSL-src {};
@@ -68,7 +69,7 @@
       system: let
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [thyme.overlays.${system}.default overlay];
+          overlays = [overlay];
         };
 
         hspkgs = pkgs.haskellPackages;


### PR DESCRIPTION
This has the added benefit that `release-23.05` now includes `thyme 0.4` which obviates the need to use a custom `thyme` version.