### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,16 @@ uname_s := $(shell uname -s)
 uname_m := $(shell uname -m)
 
 # system specific variables, add more here
-DOCKER.Linux.x86_64 := sudo docker
+
+# On linux systems, you can access docker directly if you're in the docker group.
+DOCKER_GROUP := $(shell groups | tr ' ' '\n' | grep -w docker)
+
+ifeq ($(DOCKER_GROUP),docker)
+	DOCKER.Linux.x86_64 := docker
+else
+	DOCKER.Linux.x86_64 := sudo docker
+endif
+
 DOCKER.Darwin.x86_64 := docker
 DOCKER += $(DOCKER.$(uname_s).$(uname_m))
 

--- a/Makefile
+++ b/Makefile
@@ -29,14 +29,20 @@ build-client-image:
 
 build-images: build-server-image build-client-image
 
-deploy-server-image: build-server-image
+deploy-local-server-image: build-server-image
 	$(DOCKER) tag aftok/aftok-server:latest aftok/aftok-server:$(VERSION)
+
+deploy-local-client-image: build-client-image
+	$(DOCKER) tag aftok/aftok-client:latest aftok/aftok-client:$(VERSION)
+
+deploy-server-image: deploy-local-server-image
 	$(DOCKER) push docker.io/aftok/aftok-server:latest
 	$(DOCKER) push docker.io/aftok/aftok-server:$(VERSION)
 
-deploy-client-image: build-client-image
-	$(DOCKER) tag aftok/aftok-client:latest aftok/aftok-client:$(VERSION)
+deploy-client-image: deploy-local-client-image
 	$(DOCKER) push docker.io/aftok/aftok-client:latest
 	$(DOCKER) push docker.io/aftok/aftok-client:$(VERSION)
 
 deploy-images: deploy-server-image deploy-client-image
+
+deploy-local-images: deploy-local-server-image deploy-local-client-image


### PR DESCRIPTION
A small set of tweaks to the Makefile to simplify development tasks:

* Check if the user is in the `docker` group before using `sudo` with docker
* Shim in a set of pre- targets to allow tagging without pushing to docker.io