### PR TITLE
Migrate API types from freeformObject to autodocodec-derived schemas

### DIFF
--- a/api/aftok-api.cabal
+++ b/api/aftok-api.cabal
@@ -29,6 +29,7 @@ library
   hs-source-dirs:     src
   exposed-modules:
     Aftok.API
+    Aftok.API.Codec
     Aftok.API.Types
     Aftok.API.Auth
     Aftok.API.Users
@@ -47,6 +48,8 @@ library
     relude >= 1.1.0 && < 1.3,
     aftok,
     aeson >= 2.0.3 && < 2.3,
+    autodocodec >= 0.4 && < 0.6,
+    autodocodec-openapi3 >= 0.2 && < 0.4,
     bytestring >= 0.11.4 && < 0.13,
     containers >= 0.6.5 && < 0.8,
     hourglass >= 0.2.12 && < 0.3,

--- a/api/src/Aftok/API/Auctions.hs
+++ b/api/src/Aftok/API/Auctions.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Auctions API types for the Aftok API.
 module Aftok.API.Auctions
@@ -16,8 +18,12 @@ module Aftok.API.Auctions
   )
 where
 
+import Aftok.API.Codec ()
 import Aftok.API.Types ()
 import Aftok.Auction (AuctionId)
+import Autodocodec (HasCodec (..), object, optionalField', requiredField')
+import qualified Autodocodec as AC
+import Autodocodec.Aeson (toJSONViaCodec)
 import Data.Aeson
   ( FromJSON (..),
     ToJSON (..),
@@ -36,11 +42,17 @@ import Servant.API
 
 -- | Auction creation response
 data AuctionCreateResponse = AuctionCreateResponse
-  { auctionId :: AuctionId
+  { acrAuctionId :: AuctionId
   }
   deriving (Generic)
 
-instance ToJSON AuctionCreateResponse
+instance HasCodec AuctionCreateResponse where
+  codec =
+    object "AuctionCreateResponse" $
+      AuctionCreateResponse
+        <$> requiredField' "auctionId" AC..= acrAuctionId
+
+instance ToJSON AuctionCreateResponse where toJSON = toJSONViaCodec
 
 -- | Auction creation request
 data AuctionCreateRequest = AuctionCreateRequest
@@ -61,6 +73,31 @@ instance FromJSON AuctionCreateRequest where
       <*> auctions .: "auctionStart"
       <*> auctions .: "auctionEnd"
 
+-- | The inner "auctions" object for AuctionCreateRequest codec
+data AuctionInner = AuctionInner
+  { aiName :: Text,
+    aiDescription :: Maybe Text,
+    aiRaiseAmount :: Value,
+    aiStart :: C.UTCTime,
+    aiEnd :: C.UTCTime
+  }
+
+instance HasCodec AuctionInner where
+  codec =
+    object "AuctionInner" $
+      AuctionInner
+        <$> requiredField' "auctionName" AC..= aiName
+        <*> optionalField' "auctionDesc" AC..= aiDescription
+        <*> requiredField' "raiseAmount" AC..= aiRaiseAmount
+        <*> requiredField' "auctionStart" AC..= aiStart
+        <*> requiredField' "auctionEnd" AC..= aiEnd
+
+instance HasCodec AuctionCreateRequest where
+  codec =
+    object "AuctionCreateRequest" $
+      (\inner -> AuctionCreateRequest (aiName inner) (aiDescription inner) (aiRaiseAmount inner) (aiStart inner) (aiEnd inner))
+        <$> requiredField' "auctions" AC..= (\r -> AuctionInner (acrName r) (acrDescription r) (acrRaiseAmount r) (acrAuctionStart r) (acrAuctionEnd r))
+
 -- | Bid creation request
 data BidCreateRequest = BidCreateRequest
   { bcrBidSeconds :: Int,
@@ -73,6 +110,25 @@ instance FromJSON BidCreateRequest where
     BidCreateRequest
       <$> bids .: "bidSeconds"
       <*> bids .: "bidAmount"
+
+-- | The inner "bids" object for BidCreateRequest codec
+data BidInner = BidInner
+  { biSeconds :: Int,
+    biAmount :: Value
+  }
+
+instance HasCodec BidInner where
+  codec =
+    object "BidInner" $
+      BidInner
+        <$> requiredField' "bidSeconds" AC..= biSeconds
+        <*> requiredField' "bidAmount" AC..= biAmount
+
+instance HasCodec BidCreateRequest where
+  codec =
+    object "BidCreateRequest" $
+      (\inner -> BidCreateRequest (biSeconds inner) (biAmount inner))
+        <$> requiredField' "bids" AC..= (\r -> BidInner (bcrBidSeconds r) (bcrBidAmount r))
 
 --------------------------------------------------------------------------------
 -- API Types

--- a/api/src/Aftok/API/Auth.hs
+++ b/api/src/Aftok/API/Auth.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Authentication types for the Aftok API.
 module Aftok.API.Auth
@@ -13,10 +15,11 @@ module Aftok.API.Auth
   )
 where
 
+import Aftok.API.Codec ()
 import Aftok.Types (UserId (..))
-import Data.Aeson (FromJSON (..), ToJSON (..), (.:), (.=))
-import qualified Data.Aeson as A
-import qualified Data.UUID as UUID
+import Autodocodec (HasCodec (..), object, requiredField', (.=))
+import Autodocodec.Aeson (parseJSONViaCodec, toJSONViaCodec)
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Servant.Auth (Auth, BasicAuth, Cookie, JWT)
 import Servant.Auth.Server (FromJWT, ToJWT)
 
@@ -27,21 +30,16 @@ data AuthenticatedUser = AuthenticatedUser
   }
   deriving (Eq, Show, Generic)
 
-instance ToJSON AuthenticatedUser where
-  toJSON (AuthenticatedUser (UserId uid) uname) =
-    A.object
-      [ "userId" .= UUID.toText uid,
-        "username" .= uname
-      ]
+instance HasCodec AuthenticatedUser where
+  codec =
+    object "AuthenticatedUser" $
+      AuthenticatedUser
+        <$> requiredField' "userId" .= auUserId
+        <*> requiredField' "username" .= auUsername
 
-instance FromJSON AuthenticatedUser where
-  parseJSON = A.withObject "AuthenticatedUser" $ \o -> do
-    uidText <- o .: "userId"
-    uid <- case UUID.fromText uidText of
-      Nothing -> fail "Invalid UUID for userId"
-      Just u -> pure $ UserId u
-    uname <- o .: "username"
-    pure $ AuthenticatedUser uid uname
+instance ToJSON AuthenticatedUser where toJSON = toJSONViaCodec
+
+instance FromJSON AuthenticatedUser where parseJSON = parseJSONViaCodec
 
 -- For JWT/cookie auth
 instance ToJWT AuthenticatedUser
@@ -55,10 +53,14 @@ data LoginRequest = LoginRequest
   }
   deriving (Eq, Show, Generic)
 
-instance FromJSON LoginRequest where
-  parseJSON (A.Object o) =
-    LoginRequest <$> o .: "username" <*> o .: "password"
-  parseJSON val = fail $ "Value " <> show val <> " is not a JSON object."
+instance HasCodec LoginRequest where
+  codec =
+    object "LoginRequest" $
+      LoginRequest
+        <$> requiredField' "username" .= loginUser
+        <*> requiredField' "password" .= loginPass
+
+instance FromJSON LoginRequest where parseJSON = parseJSONViaCodec
 
 -- | Auth configuration type for servant-auth
 type AftokAuth = Auth '[BasicAuth, Cookie, JWT] AuthenticatedUser

--- a/api/src/Aftok/API/Billing.hs
+++ b/api/src/Aftok/API/Billing.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Billing API types for the Aftok API.
 module Aftok.API.Billing
@@ -22,24 +24,20 @@ module Aftok.API.Billing
   )
 where
 
+import Aftok.API.Codec ()
 import Aftok.API.Types ()
 import Aftok.Billing (BillableId (..), Recurrence (..), SubscriptionId)
 import Aftok.Payments.Types (PaymentRequestId (..))
+import Autodocodec (HasCodec (..), object, optionalField', requiredField')
+import qualified Autodocodec as AC
+import Autodocodec.Aeson (parseJSONViaCodec, toJSONViaCodec)
 import Data.Aeson
   ( FromJSON (..),
-    Object,
     ToJSON (..),
-    Value (..),
-    (.:),
-    (.:?),
-    (.=),
+    Value,
   )
-import qualified Data.Aeson as A
-import qualified Data.Aeson.KeyMap as O
-import Data.Aeson.Types (Parser)
 import qualified Data.Thyme.Clock as C
 import Data.Thyme.Format.Aeson ()
-import qualified Data.UUID as UUID
 import Servant.API
 
 --------------------------------------------------------------------------------
@@ -48,21 +46,33 @@ import Servant.API
 
 -- | Billable creation response
 data BillableCreateResponse = BillableCreateResponse
-  { billableId :: BillableId
+  { bcrBillableId :: BillableId
   }
   deriving (Generic)
 
-instance ToJSON BillableCreateResponse
+instance HasCodec BillableCreateResponse where
+  codec =
+    object "BillableCreateResponse" $
+      BillableCreateResponse
+        <$> requiredField' "billableId" AC..= bcrBillableId
+
+instance ToJSON BillableCreateResponse where toJSON = toJSONViaCodec
 
 -- | Subscription creation response
 data SubscribeResponse = SubscribeResponse
-  { subscriptionId :: SubscriptionId
+  { srSubscriptionId :: SubscriptionId
   }
   deriving (Generic)
 
-instance ToJSON SubscribeResponse
+instance HasCodec SubscribeResponse where
+  codec =
+    object "SubscribeResponse" $
+      SubscribeResponse
+        <$> requiredField' "subscriptionId" AC..= srSubscriptionId
 
--- | Billable creation request
+instance ToJSON SubscribeResponse where toJSON = toJSONViaCodec
+
+-- | Billable creation request (nested format with schemaVersion)
 data BillableCreateRequest = BillableCreateRequest
   { bcrName :: Text,
     bcrDescription :: Text,
@@ -76,22 +86,68 @@ data BillableCreateRequest = BillableCreateRequest
     bcrPaymentRequestMemoTemplate :: Maybe Text
   }
 
-instance FromJSON BillableCreateRequest where
-  parseJSON = A.withObject "BillableCreateRequest" $ \outer -> do
-    v <- outer .: "schemaVersion"
-    when ((v :: Text) /= "1.0") $ fail "Unsupported schema version"
-    o <- outer .: "Billable"
-    BillableCreateRequest
-      <$> o .: "name"
-      <*> o .: "description"
-      <*> o .: "message"
-      <*> (parseRecurrence' =<< o .: "recurrence")
-      <*> o .: "currency"
-      <*> o .: "amount"
-      <*> o .: "gracePeriod"
-      <*> o .: "requestExpiryPeriod"
-      <*> o .:? "paymentRequestEmailTemplate"
-      <*> o .:? "paymentRequestMemoTemplate"
+instance FromJSON BillableCreateRequest where parseJSON = parseJSONViaCodec
+
+-- | Inner billable object for the codec
+data BillableInner = BillableInner
+  { biName :: Text,
+    biDescription :: Text,
+    biMessage :: Text,
+    biRecurrence :: Recurrence,
+    biCurrency :: Text,
+    biAmount :: Int,
+    biGracePeriod :: Int,
+    biRequestExpiryPeriod :: Int,
+    biPaymentRequestEmailTemplate :: Maybe Text,
+    biPaymentRequestMemoTemplate :: Maybe Text
+  }
+
+instance HasCodec BillableInner where
+  codec =
+    object "BillableInner" $
+      BillableInner
+        <$> requiredField' "name" AC..= biName
+        <*> requiredField' "description" AC..= biDescription
+        <*> requiredField' "message" AC..= biMessage
+        <*> requiredField' "recurrence" AC..= biRecurrence
+        <*> requiredField' "currency" AC..= biCurrency
+        <*> requiredField' "amount" AC..= biAmount
+        <*> requiredField' "gracePeriod" AC..= biGracePeriod
+        <*> requiredField' "requestExpiryPeriod" AC..= biRequestExpiryPeriod
+        <*> optionalField' "paymentRequestEmailTemplate" AC..= biPaymentRequestEmailTemplate
+        <*> optionalField' "paymentRequestMemoTemplate" AC..= biPaymentRequestMemoTemplate
+
+instance HasCodec BillableCreateRequest where
+  codec =
+    object "BillableCreateRequest" $
+      ( \_ inner ->
+          BillableCreateRequest
+            (biName inner)
+            (biDescription inner)
+            (biMessage inner)
+            (biRecurrence inner)
+            (biCurrency inner)
+            (biAmount inner)
+            (biGracePeriod inner)
+            (biRequestExpiryPeriod inner)
+            (biPaymentRequestEmailTemplate inner)
+            (biPaymentRequestMemoTemplate inner)
+      )
+        <$> requiredField' "schemaVersion" AC..= (const ("1.0" :: Text))
+        <*> requiredField' "Billable"
+          AC..= ( \r ->
+                    BillableInner
+                      (bcrName r)
+                      (bcrDescription r)
+                      (bcrMessage r)
+                      (bcrRecurrence r)
+                      (bcrCurrency r)
+                      (bcrAmount r)
+                      (bcrGracePeriod r)
+                      (bcrRequestExpiryPeriod r)
+                      (bcrPaymentRequestEmailTemplate r)
+                      (bcrPaymentRequestMemoTemplate r)
+                )
 
 -- | Subscribe request (currently empty, billableId comes from URL)
 data SubscribeRequest = SubscribeRequest
@@ -119,18 +175,20 @@ data BillableResponse = BillableResponse
     brRequestExpiryPeriod :: Int
   }
 
-instance ToJSON BillableResponse where
-  toJSON r =
-    A.object
-      [ "billableId" .= (let BillableId u = brBillableId r in UUID.toText u),
-        "name" .= brName r,
-        "description" .= brDescription r,
-        "message" .= brMessage r,
-        "recurrence" .= recurrenceToJSON (brRecurrence r),
-        "amount" .= brAmount r,
-        "gracePeriod" .= brGracePeriod r,
-        "requestExpiryPeriod" .= brRequestExpiryPeriod r
-      ]
+instance HasCodec BillableResponse where
+  codec =
+    object "BillableResponse" $
+      BillableResponse
+        <$> requiredField' "billableId" AC..= brBillableId
+        <*> requiredField' "name" AC..= brName
+        <*> requiredField' "description" AC..= brDescription
+        <*> requiredField' "message" AC..= brMessage
+        <*> requiredField' "recurrence" AC..= brRecurrence
+        <*> requiredField' "amount" AC..= brAmount
+        <*> requiredField' "gracePeriod" AC..= brGracePeriod
+        <*> requiredField' "requestExpiryPeriod" AC..= brRequestExpiryPeriod
+
+instance ToJSON BillableResponse where toJSON = toJSONViaCodec
 
 -- | Payment request response
 data PaymentRequestResponse = PaymentRequestResponse
@@ -140,14 +198,16 @@ data PaymentRequestResponse = PaymentRequestResponse
     prrNativeRequest :: Value
   }
 
-instance ToJSON PaymentRequestResponse where
-  toJSON r =
-    A.object
-      [ "payment_request_id" .= (let PaymentRequestId u = prrPaymentRequestId r in UUID.toText u),
-        "total" .= prrTotal r,
-        "expires_at" .= prrExpiresAt r,
-        "native_request" .= prrNativeRequest r
-      ]
+instance HasCodec PaymentRequestResponse where
+  codec =
+    object "PaymentRequestResponse" $
+      PaymentRequestResponse
+        <$> requiredField' "payment_request_id" AC..= prrPaymentRequestId
+        <*> requiredField' "total" AC..= prrTotal
+        <*> requiredField' "expires_at" AC..= prrExpiresAt
+        <*> requiredField' "native_request" AC..= prrNativeRequest
+
+instance ToJSON PaymentRequestResponse where toJSON = toJSONViaCodec
 
 --------------------------------------------------------------------------------
 -- API Types
@@ -174,41 +234,3 @@ type ProjectBillablesAPI =
       :> "paymentRequests"
       :> ReqBody '[JSON] PaymentRequestCreateRequest
       :> Post '[JSON] PaymentRequestResponse
-
---------------------------------------------------------------------------------
--- Serialization Helpers
---------------------------------------------------------------------------------
-
--- | Serialize recurrence to JSON (matches handler's existing shape)
-recurrenceToJSON :: Recurrence -> Value
-recurrenceToJSON = \case
-  Annually -> A.object ["annually" .= A.Null]
-  Monthly d -> A.object ["monthly" .= d]
-  Weekly d -> A.object ["weekly" .= d]
-  OneTime -> A.object ["onetime" .= A.Null]
-
---------------------------------------------------------------------------------
--- Parsing Helpers
---------------------------------------------------------------------------------
-
--- | Parse a recurrence value from JSON
-parseRecurrence :: Object -> Parser Recurrence
-parseRecurrence o =
-  let parseAnnually o' = const (pure Annually) <$> O.lookup "annually" o'
-      parseMonthly o' = fmap Monthly . A.parseJSON <$> O.lookup "monthly" o'
-      parseWeekly o' = fmap Weekly . A.parseJSON <$> O.lookup "weekly" o'
-      parseOneTime o' = const (pure OneTime) <$> O.lookup "onetime" o'
-      notFound =
-        fail $ "Value " <> show o <> " does not represent a Recurrence value."
-      parseV val =
-        parseAnnually val
-          <|> parseMonthly val
-          <|> parseWeekly val
-          <|> parseOneTime val
-   in fromMaybe notFound $ parseV o
-
--- | Parse a recurrence from a JSON value
-parseRecurrence' :: Value -> Parser Recurrence
-parseRecurrence' = \case
-  (Object o) -> parseRecurrence o
-  val -> fail $ "Value " <> show val <> " is not a JSON object."

--- a/api/src/Aftok/API/Codec.hs
+++ b/api/src/Aftok/API/Codec.hs
@@ -1,0 +1,229 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- | Autodocodec 'HasCodec' instances for core library types that appear
+-- in API request/response types. These codecs define the API wire format
+-- only — the database layer has its own serialization and is unaffected.
+module Aftok.API.Codec () where
+
+import Aftok.Auction (AuctionId (..))
+import Aftok.Billing (BillableId (..), Recurrence (..), SubscriptionId (..))
+import Aftok.Payments.Types (PaymentId (..), PaymentRequestId (..))
+import Aftok.TimeLog (AmendmentId (..), EventId (..), LogEvent (..))
+import Aftok.Types
+  ( AccountId (..),
+    CreditTo (..),
+    DepreciationFunction (..),
+    ProjectId (..),
+    UserId (..),
+    UserName (..),
+  )
+import Autodocodec
+  ( HasCodec (..),
+    JSONCodec,
+    bimapCodec,
+    dimapCodec,
+    disjointEitherCodec,
+    object,
+    optionalField,
+    requiredField',
+    (.=),
+    (<?>),
+  )
+import qualified Data.Thyme.Clock as C
+import Data.Thyme.Time.Core (fromThyme, toThyme)
+import qualified Data.Time as Time
+import qualified Data.UUID as UUID
+
+--------------------------------------------------------------------------------
+-- UUID wrapper types
+--------------------------------------------------------------------------------
+
+uuidCodec :: (a -> UUID.UUID) -> (UUID.UUID -> a) -> Text -> JSONCodec a
+uuidCodec unwrap wrap name =
+  bimapCodec
+    (maybe (Left "Invalid UUID") Right . fmap wrap . UUID.fromText)
+    (UUID.toText . unwrap)
+    (codec @Text <?> name)
+
+instance HasCodec UserId where
+  codec = uuidCodec (\(UserId u) -> u) UserId "UserId UUID"
+
+instance HasCodec ProjectId where
+  codec = uuidCodec (\(ProjectId u) -> u) ProjectId "ProjectId UUID"
+
+instance HasCodec AccountId where
+  codec = uuidCodec (\(AccountId u) -> u) AccountId "AccountId UUID"
+
+instance HasCodec EventId where
+  codec = uuidCodec (\(EventId u) -> u) EventId "EventId UUID"
+
+instance HasCodec AmendmentId where
+  codec = uuidCodec (\(AmendmentId u) -> u) AmendmentId "AmendmentId UUID"
+
+instance HasCodec BillableId where
+  codec = uuidCodec (\(BillableId u) -> u) BillableId "BillableId UUID"
+
+instance HasCodec AuctionId where
+  codec = uuidCodec (\(AuctionId u) -> u) AuctionId "AuctionId UUID"
+
+instance HasCodec SubscriptionId where
+  codec = uuidCodec (\(SubscriptionId u) -> u) SubscriptionId "SubscriptionId UUID"
+
+instance HasCodec PaymentRequestId where
+  codec = uuidCodec (\(PaymentRequestId u) -> u) PaymentRequestId "PaymentRequestId UUID"
+
+instance HasCodec PaymentId where
+  codec = uuidCodec (\(PaymentId u) -> u) PaymentId "PaymentId UUID"
+
+--------------------------------------------------------------------------------
+-- Thyme UTCTime
+--------------------------------------------------------------------------------
+
+instance HasCodec C.UTCTime where
+  codec = dimapCodec toThyme fromThyme (codec @Time.UTCTime)
+
+--------------------------------------------------------------------------------
+-- Simple newtypes
+--------------------------------------------------------------------------------
+
+instance HasCodec UserName where
+  codec = dimapCodec UserName (\(UserName t) -> t) codec
+
+--------------------------------------------------------------------------------
+-- CreditTo
+--
+-- Matches existing creditToJSON/parseCreditToV2 format:
+--   {"creditToAccount": "<uuid>"}
+
+-- | {"creditToUser": "<uuid>"}
+-- | {"creditToProject": "<uuid>"}
+
+--------------------------------------------------------------------------------
+
+instance HasCodec CreditTo where
+  codec =
+    dimapCodec fromEither toEither $
+      disjointEitherCodec accountCodec $
+        disjointEitherCodec userCodec projectCodec
+    where
+      accountCodec =
+        object "CreditToAccount" $
+          requiredField' "creditToAccount" .= id
+      userCodec =
+        object "CreditToUser" $
+          requiredField' "creditToUser" .= id
+      projectCodec =
+        object "CreditToProject" $
+          requiredField' "creditToProject" .= id
+      fromEither :: Either AccountId (Either UserId ProjectId) -> CreditTo
+      fromEither = \case
+        Left a -> CreditToAccount a
+        Right (Left u) -> CreditToUser u
+        Right (Right p) -> CreditToProject p
+      toEither :: CreditTo -> Either AccountId (Either UserId ProjectId)
+      toEither = \case
+        CreditToAccount a -> Left a
+        CreditToUser u -> Right (Left u)
+        CreditToProject p -> Right (Right p)
+
+--------------------------------------------------------------------------------
+-- DepreciationFunction
+--
+-- Matches existing depfToJSON/depfFromJSON format:
+--   {"type": "LinearDepreciation", "arguments": {"undep": N, "dep": N}}
+--------------------------------------------------------------------------------
+
+-- Helper type for the nested "arguments" object
+data LinearDepArgs = LinearDepArgs Int Int
+
+instance HasCodec LinearDepArgs where
+  codec =
+    object "LinearDepreciationArgs" $
+      LinearDepArgs
+        <$> requiredField' "undep" .= (\(LinearDepArgs u _) -> u)
+        <*> requiredField' "dep" .= (\(LinearDepArgs _ d) -> d)
+
+instance HasCodec DepreciationFunction where
+  codec =
+    object "DepreciationFunction" $
+      (\_ args -> case args of LinearDepArgs u d -> LinearDepreciation u d)
+        <$> requiredField' "type" .= (\(LinearDepreciation _ _) -> ("LinearDepreciation" :: Text))
+        <*> requiredField' "arguments" .= (\(LinearDepreciation u d) -> LinearDepArgs u d)
+
+--------------------------------------------------------------------------------
+-- LogEvent
+--
+-- Matches existing logEventToJSON format:
+--   {"start": {"eventTime": "<iso8601>"}}
+
+-- | {"stop": {"eventTime": "<iso8601>"}}
+
+--------------------------------------------------------------------------------
+
+newtype EventTimeWrapper = EventTimeWrapper C.UTCTime
+
+instance HasCodec EventTimeWrapper where
+  codec =
+    object "EventTime" $
+      EventTimeWrapper <$> requiredField' "eventTime" .= (\(EventTimeWrapper t) -> t)
+
+instance HasCodec LogEvent where
+  codec =
+    dimapCodec fromEither toEither $
+      disjointEitherCodec startCodec stopCodec
+    where
+      startCodec =
+        object "StartWork" $
+          requiredField' "start" .= id
+      stopCodec =
+        object "StopWork" $
+          requiredField' "stop" .= id
+      fromEither :: Either EventTimeWrapper EventTimeWrapper -> LogEvent
+      fromEither = \case
+        Left (EventTimeWrapper t) -> StartWork t
+        Right (EventTimeWrapper t) -> StopWork t
+      toEither :: LogEvent -> Either EventTimeWrapper EventTimeWrapper
+      toEither = \case
+        StartWork t -> Left (EventTimeWrapper t)
+        StopWork t -> Right (EventTimeWrapper t)
+
+--------------------------------------------------------------------------------
+-- Recurrence
+--
+-- Matches existing recurrenceToJSON/parseRecurrence format:
+--   {"annually": null} | {"monthly": N} | {"weekly": N} | {"onetime": null}
+--------------------------------------------------------------------------------
+
+instance HasCodec Recurrence where
+  codec =
+    dimapCodec fromEither toEither $
+      disjointEitherCodec annuallyCodec $
+        disjointEitherCodec monthlyCodec $
+          disjointEitherCodec weeklyCodec onetimeCodec
+    where
+      annuallyCodec =
+        object "Annually" $
+          optionalField "annually" "null marker" .= id
+      monthlyCodec =
+        object "Monthly" $
+          requiredField' "monthly" .= id
+      weeklyCodec =
+        object "Weekly" $
+          requiredField' "weekly" .= id
+      onetimeCodec =
+        object "OneTime" $
+          optionalField "onetime" "null marker" .= id
+      fromEither :: Either (Maybe Int) (Either Int (Either Int (Maybe Int))) -> Recurrence
+      fromEither = \case
+        Left _ -> Annually
+        Right (Left n) -> Monthly n
+        Right (Right (Left n)) -> Weekly n
+        Right (Right (Right _)) -> OneTime
+      toEither :: Recurrence -> Either (Maybe Int) (Either Int (Either Int (Maybe Int)))
+      toEither = \case
+        Annually -> Left Nothing
+        Monthly n -> Right (Left n)
+        Weekly n -> Right (Right (Left n))
+        OneTime -> Right (Right (Right Nothing))

--- a/api/src/Aftok/API/Config.hs
+++ b/api/src/Aftok/API/Config.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Config API types for the Aftok API.
 module Aftok.API.Config
@@ -12,7 +14,10 @@ module Aftok.API.Config
   )
 where
 
-import Data.Aeson (ToJSON)
+import Autodocodec (HasCodec (..), object, requiredField')
+import qualified Autodocodec as AC
+import Autodocodec.Aeson (toJSONViaCodec)
+import Data.Aeson (ToJSON (..))
 import Servant.API
 
 -- | Client configuration returned by the server
@@ -21,7 +26,13 @@ data ClientConfig = ClientConfig
   }
   deriving (Show, Generic)
 
-instance ToJSON ClientConfig
+instance HasCodec ClientConfig where
+  codec =
+    object "ClientConfig" $
+      ClientConfig
+        <$> requiredField' "recaptchaSiteKey" AC..= recaptchaSiteKey
+
+instance ToJSON ClientConfig where toJSON = toJSONViaCodec
 
 -- | Configuration API - public endpoint for client config
 type ConfigAPI =

--- a/api/src/Aftok/API/OpenApi.hs
+++ b/api/src/Aftok/API/OpenApi.hs
@@ -22,6 +22,7 @@ import Aftok.API.Billing
     SubscribeRequest,
     SubscribeResponse,
   )
+import Aftok.API.Codec ()
 import Aftok.API.Config (ClientConfig)
 import Aftok.API.PasswordReset
   ( PasswordResetConfirm,
@@ -63,6 +64,7 @@ import Aftok.Auction (AuctionId (..))
 import Aftok.Billing (BillableId (..), SubscriptionId (..))
 import Aftok.Payments.Types (PaymentId (..))
 import Aftok.Types (ProjectId (..), UserId (..))
+import Autodocodec.OpenAPI (declareNamedSchemaViaCodec)
 import Control.Lens ((.~), (?~))
 import qualified Data.Aeson as A
 import Data.OpenApi
@@ -126,26 +128,26 @@ instance ToParamSchema C.UTCTime where
       ?~ "date-time"
 
 --------------------------------------------------------------------------------
--- ToSchema instances for core types
+-- ToSchema instances for core types (codec-derived)
 --------------------------------------------------------------------------------
 
 instance ToSchema ProjectId where
-  declareNamedSchema _ = pure $ NamedSchema (Just "ProjectId") uuidParamSchema
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema UserId where
-  declareNamedSchema _ = pure $ NamedSchema (Just "UserId") uuidParamSchema
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema BillableId where
-  declareNamedSchema _ = pure $ NamedSchema (Just "BillableId") uuidParamSchema
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema AuctionId where
-  declareNamedSchema _ = pure $ NamedSchema (Just "AuctionId") uuidParamSchema
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema SubscriptionId where
-  declareNamedSchema _ = pure $ NamedSchema (Just "SubscriptionId") uuidParamSchema
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema PaymentId where
-  declareNamedSchema _ = pure $ NamedSchema (Just "PaymentId") uuidParamSchema
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 -- | thyme UTCTime → delegate to time's UTCTime schema
 instance ToSchema C.UTCTime where
@@ -154,18 +156,8 @@ instance ToSchema C.UTCTime where
     pure $ s {_namedSchemaName = Just "UTCTime"}
 
 --------------------------------------------------------------------------------
--- ToSchema instances for API request/response types
---
--- Types with custom ToJSON instances use a simple freeform object schema.
--- This is pragmatic: the ToJSON instances hand-write field names that don't
--- match Haskell record fields, so Generic-based derivation would be wrong.
+-- ToSchema instances for special types
 --------------------------------------------------------------------------------
-
-freeformObject :: Text -> OA.NamedSchema
-freeformObject name =
-  NamedSchema
-    (Just name)
-    (mempty & OA.type_ ?~ OA.OpenApiObject)
 
 -- | Aeson Value as freeform JSON — used by untyped response endpoints
 instance ToSchema A.Value where
@@ -175,131 +167,155 @@ instance ToSchema A.Value where
 instance ToSchema BIP70Data where
   declareNamedSchema _ = pure $ NamedSchema (Just "BIP70Data") OA.binarySchema
 
+--------------------------------------------------------------------------------
+-- ToSchema instances for API request/response types (codec-derived)
+--------------------------------------------------------------------------------
+
 -- Auth
 instance ToSchema AuthenticatedUser where
-  declareNamedSchema _ = pure $ freeformObject "AuthenticatedUser"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema LoginRequest where
-  declareNamedSchema _ = pure $ freeformObject "LoginRequest"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 -- Users
 instance ToSchema RegisterRequest where
-  declareNamedSchema _ = pure $ freeformObject "RegisterRequest"
+  declareNamedSchema _ =
+    pure $
+      NamedSchema
+        (Just "RegisterRequest")
+        (mempty & OA.type_ ?~ OA.OpenApiObject)
 
 instance ToSchema RegisterResponse where
-  declareNamedSchema _ = pure $ freeformObject "RegisterResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema UsernameCheckResponse where
-  declareNamedSchema _ = pure $ freeformObject "UsernameCheckResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema ZAddrCheckResponse where
-  declareNamedSchema _ = pure $ freeformObject "ZAddrCheckResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema AccountSettingsResponse where
-  declareNamedSchema _ = pure $ freeformObject "AccountSettingsResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema SetPaymentAddressRequest where
-  declareNamedSchema _ = pure $ freeformObject "SetPaymentAddressRequest"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 -- Session
 instance ToSchema LoginCheckResponse where
-  declareNamedSchema _ = pure $ freeformObject "LoginCheckResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 -- Projects
 instance ToSchema ProjectCreateRequest where
-  declareNamedSchema _ = pure $ freeformObject "ProjectCreateRequest"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema ProjectCreateResponse where
-  declareNamedSchema _ = pure $ freeformObject "ProjectCreateResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema ProjectSummary where
-  declareNamedSchema _ = pure $ freeformObject "ProjectSummary"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema ProjectResponse where
-  declareNamedSchema _ = pure $ freeformObject "ProjectResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema ProjectDetailResponse where
-  declareNamedSchema _ = pure $ freeformObject "ProjectDetailResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema ProjectInviteRequest where
-  declareNamedSchema _ = pure $ freeformObject "ProjectInviteRequest"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema ProjectInviteResponse where
-  declareNamedSchema _ = pure $ freeformObject "ProjectInviteResponse"
+  declareNamedSchema _ =
+    pure $
+      NamedSchema
+        (Just "ProjectInviteResponse")
+        (mempty & OA.type_ ?~ OA.OpenApiObject)
 
 instance ToSchema CommsAddress where
-  declareNamedSchema _ = pure $ freeformObject "CommsAddress"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 -- WorkLog
 instance ToSchema LogStartRequest where
-  declareNamedSchema _ = pure $ freeformObject "LogStartRequest"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema LogEndRequest where
-  declareNamedSchema _ = pure $ freeformObject "LogEndRequest"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema EventAmendmentRequest where
-  declareNamedSchema _ = pure $ freeformObject "EventAmendmentRequest"
+  declareNamedSchema _ =
+    pure $
+      NamedSchema
+        (Just "EventAmendmentRequest")
+        (mempty & OA.type_ ?~ OA.OpenApiObject)
 
 instance ToSchema ExtendedLogEntryResponse where
-  declareNamedSchema _ = pure $ freeformObject "ExtendedLogEntryResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema KeyedLogEntryResponse where
-  declareNamedSchema _ = pure $ freeformObject "KeyedLogEntryResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema WorkIndexResponse where
-  declareNamedSchema _ = pure $ freeformObject "WorkIndexResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema WorkIndexEntry where
-  declareNamedSchema _ = pure $ freeformObject "WorkIndexEntry"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema IntervalResponse where
-  declareNamedSchema _ = pure $ freeformObject "IntervalResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema AmendEventResponse where
-  declareNamedSchema _ = pure $ freeformObject "AmendEventResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 -- Auctions
 instance ToSchema AuctionCreateRequest where
-  declareNamedSchema _ = pure $ freeformObject "AuctionCreateRequest"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema AuctionCreateResponse where
-  declareNamedSchema _ = pure $ freeformObject "AuctionCreateResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema BidCreateRequest where
-  declareNamedSchema _ = pure $ freeformObject "BidCreateRequest"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 -- Billing
 instance ToSchema BillableCreateRequest where
-  declareNamedSchema _ = pure $ freeformObject "BillableCreateRequest"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema BillableCreateResponse where
-  declareNamedSchema _ = pure $ freeformObject "BillableCreateResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema BillableResponse where
-  declareNamedSchema _ = pure $ freeformObject "BillableResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema PaymentRequestCreateRequest where
-  declareNamedSchema _ = pure $ freeformObject "PaymentRequestCreateRequest"
+  declareNamedSchema _ =
+    pure $
+      NamedSchema
+        (Just "PaymentRequestCreateRequest")
+        (mempty & OA.type_ ?~ OA.OpenApiObject)
 
 instance ToSchema PaymentRequestResponse where
-  declareNamedSchema _ = pure $ freeformObject "PaymentRequestResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema SubscribeRequest where
-  declareNamedSchema _ = pure $ freeformObject "SubscribeRequest"
+  declareNamedSchema _ =
+    pure $
+      NamedSchema
+        (Just "SubscribeRequest")
+        (mempty & OA.type_ ?~ OA.OpenApiObject)
 
 instance ToSchema SubscribeResponse where
-  declareNamedSchema _ = pure $ freeformObject "SubscribeResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 -- Password Reset
 instance ToSchema PasswordResetRequest where
-  declareNamedSchema _ = pure $ freeformObject "PasswordResetRequest"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema PasswordResetResponse where
-  declareNamedSchema _ = pure $ freeformObject "PasswordResetResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema PasswordResetConfirm where
-  declareNamedSchema _ = pure $ freeformObject "PasswordResetConfirm"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 -- Config
 instance ToSchema ClientConfig where
-  declareNamedSchema _ = pure $ freeformObject "ClientConfig"
+  declareNamedSchema = declareNamedSchemaViaCodec

--- a/api/src/Aftok/API/PasswordReset.hs
+++ b/api/src/Aftok/API/PasswordReset.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Password Reset API types for the Aftok API.
 module Aftok.API.PasswordReset
@@ -14,8 +16,10 @@ module Aftok.API.PasswordReset
   )
 where
 
-import Data.Aeson (FromJSON (..), ToJSON (..), (.:), (.=))
-import qualified Data.Aeson as A
+import Autodocodec (HasCodec (..), object, optionalField', requiredField')
+import qualified Autodocodec as AC
+import Autodocodec.Aeson (parseJSONViaCodec, toJSONViaCodec)
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Servant.API
 
 -- | Password reset API
@@ -43,13 +47,14 @@ data PasswordResetRequest = PasswordResetRequest
   }
   deriving (Show, Eq, Generic)
 
-instance FromJSON PasswordResetRequest where
-  parseJSON = A.withObject "PasswordResetRequest" $ \o ->
-    PasswordResetRequest
-      <$> o .:? "username"
-      <*> o .:? "email"
-    where
-      (.:?) obj key = obj .: key <|> pure Nothing
+instance HasCodec PasswordResetRequest where
+  codec =
+    object "PasswordResetRequest" $
+      PasswordResetRequest
+        <$> optionalField' "username" AC..= prrUsername
+        <*> optionalField' "email" AC..= prrEmail
+
+instance FromJSON PasswordResetRequest where parseJSON = parseJSONViaCodec
 
 -- | Response for password reset request (always success for security)
 data PasswordResetResponse = PasswordResetResponse
@@ -57,9 +62,13 @@ data PasswordResetResponse = PasswordResetResponse
   }
   deriving (Show, Eq, Generic)
 
-instance ToJSON PasswordResetResponse where
-  toJSON (PasswordResetResponse msg) =
-    A.object ["message" .= msg]
+instance HasCodec PasswordResetResponse where
+  codec =
+    object "PasswordResetResponse" $
+      PasswordResetResponse
+        <$> requiredField' "message" AC..= prsMessage
+
+instance ToJSON PasswordResetResponse where toJSON = toJSONViaCodec
 
 -- | Confirm password reset with token
 data PasswordResetConfirm = PasswordResetConfirm
@@ -68,8 +77,11 @@ data PasswordResetConfirm = PasswordResetConfirm
   }
   deriving (Show, Eq, Generic)
 
-instance FromJSON PasswordResetConfirm where
-  parseJSON = A.withObject "PasswordResetConfirm" $ \o ->
-    PasswordResetConfirm
-      <$> o .: "token"
-      <*> o .: "newPassword"
+instance HasCodec PasswordResetConfirm where
+  codec =
+    object "PasswordResetConfirm" $
+      PasswordResetConfirm
+        <$> requiredField' "token" AC..= prcToken
+        <*> requiredField' "newPassword" AC..= prcNewPassword
+
+instance FromJSON PasswordResetConfirm where parseJSON = parseJSONViaCodec

--- a/api/src/Aftok/API/Projects.hs
+++ b/api/src/Aftok/API/Projects.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Projects API types for the Aftok API.
 module Aftok.API.Projects
@@ -36,10 +39,10 @@ where
 
 import Aftok.API.Auctions (ProjectAuctionsAPI)
 import Aftok.API.Billing (ProjectBillablesAPI)
+import Aftok.API.Codec ()
 import Aftok.API.Types ()
 import qualified Aftok.Currency.Zcash.Zip321 as Zip321
 import Aftok.Project (Project (..))
-import Aftok.TimeLog.Serialization (depfFromJSON)
 import Aftok.Types
   ( DepreciationFunction (..),
     DepreciationRules (..),
@@ -47,20 +50,20 @@ import Aftok.Types
     UserId (..),
     UserName (..),
   )
+import Autodocodec (HasCodec (..), object, optionalField', requiredField')
+import qualified Autodocodec as AC
+import Autodocodec.Aeson (parseJSONViaCodec, toJSONViaCodec)
 import Control.Lens (makeLenses)
 import Data.Aeson
   ( FromJSON (..),
     ToJSON (..),
     Value (..),
-    object,
-    (.:),
-    (.:?),
     (.=),
   )
 import qualified Data.Aeson as A
 import qualified Data.Map.Strict as M
+import Data.Ratio ((%))
 import qualified Data.Thyme.Clock as C
-import qualified Data.UUID as UUID
 import Servant.API
 import Time.Types (Hours (..))
 
@@ -74,10 +77,14 @@ data ProjectCreateRequest = ProjectCreateRequest
     cpdepf :: DepreciationFunction
   }
 
-instance FromJSON ProjectCreateRequest where
-  parseJSON (A.Object v) =
-    ProjectCreateRequest <$> v .: "projectName" <*> (depfFromJSON =<< v .: "depf")
-  parseJSON _ = mzero
+instance FromJSON ProjectCreateRequest where parseJSON = parseJSONViaCodec
+
+instance HasCodec ProjectCreateRequest where
+  codec =
+    object "ProjectCreateRequest" $
+      ProjectCreateRequest
+        <$> requiredField' "projectName" AC..= cpn
+        <*> requiredField' "depf" AC..= cpdepf
 
 -- | Contributor record for project detail
 data Contributor = Contributor
@@ -104,6 +111,22 @@ data CommsAddress
   = EmailComms Text
   | ZcashComms Text
 
+instance HasCodec CommsAddress where
+  codec =
+    AC.dimapCodec fromEither toEither $
+      AC.disjointEitherCodec emailCodec zAddrCodec
+    where
+      emailCodec = object "EmailComms" $ requiredField' "email" AC..= id
+      zAddrCodec = object "ZcashComms" $ requiredField' "zaddr" AC..= id
+      fromEither :: Either Text Text -> CommsAddress
+      fromEither = \case
+        Left e -> EmailComms e
+        Right z -> ZcashComms z
+      toEither :: CommsAddress -> Either Text Text
+      toEither = \case
+        EmailComms e -> Left e
+        ZcashComms z -> Right z
+
 -- | Project invitation request
 data ProjectInviteRequest = ProjectInviteRequest
   { greetName :: Text,
@@ -111,17 +134,15 @@ data ProjectInviteRequest = ProjectInviteRequest
     inviteBy :: CommsAddress
   }
 
-instance FromJSON ProjectInviteRequest where
-  parseJSON (A.Object v) = do
-    name <- v .: "greetName"
-    msg <- v .:? "message"
-    comms <- v .: "inviteBy"
-    emailComms <- fmap EmailComms <$> (comms .:? "email")
-    zcashComms <- fmap ZcashComms <$> (comms .:? "zaddr")
-    case emailComms <|> zcashComms of
-      Nothing -> mzero
-      Just addr -> pure $ ProjectInviteRequest name msg addr
-  parseJSON _ = mzero
+instance FromJSON ProjectInviteRequest where parseJSON = parseJSONViaCodec
+
+instance HasCodec ProjectInviteRequest where
+  codec =
+    object "ProjectInviteRequest" $
+      ProjectInviteRequest
+        <$> requiredField' "greetName" AC..= greetName
+        <*> optionalField' "message" AC..= pirMessage
+        <*> requiredField' "inviteBy" AC..= inviteBy
 
 -- | Project invitation response
 data ProjectInviteResponse = ProjectInviteResponse
@@ -130,9 +151,9 @@ data ProjectInviteResponse = ProjectInviteResponse
   deriving (Generic)
 
 instance ToJSON ProjectInviteResponse where
-  toJSON (ProjectInviteResponse Nothing) = object []
+  toJSON (ProjectInviteResponse Nothing) = A.object []
   toJSON (ProjectInviteResponse (Just r)) =
-    object ["zip321_request" .= (A.toJSON . Zip321.toURI $ r)]
+    A.object ["zip321_request" .= (A.toJSON . Zip321.toURI $ r)]
 
 --------------------------------------------------------------------------------
 -- Response Types (defined after TH splices)
@@ -140,19 +161,65 @@ instance ToJSON ProjectInviteResponse where
 
 -- | Project creation response
 data ProjectCreateResponse = ProjectCreateResponse
-  { projectId :: ProjectId
+  { pcrProjectId :: ProjectId
   }
   deriving (Generic)
 
-instance ToJSON ProjectCreateResponse
+instance HasCodec ProjectCreateResponse where
+  codec =
+    object "ProjectCreateResponse" $
+      ProjectCreateResponse
+        <$> requiredField' "projectId" AC..= pcrProjectId
+
+instance ToJSON ProjectCreateResponse where toJSON = toJSONViaCodec
+
+-- | Helper codec for serializing a Project to a flat JSON object
+projectCodec :: AC.JSONObjectCodec ProjectFields
+projectCodec =
+  ProjectFields
+    <$> requiredField' "projectName" AC..= pfName
+    <*> requiredField' "inceptionDate" AC..= pfInceptionDate
+    <*> requiredField' "initiator" AC..= pfInitiator
+    <*> requiredField' "depf" AC..= pfDepf
+
+data ProjectFields = ProjectFields
+  { pfName :: Text,
+    pfInceptionDate :: C.UTCTime,
+    pfInitiator :: UserId,
+    pfDepf :: DepreciationFunction
+  }
+
+instance HasCodec ProjectFields where
+  codec = object "Project" projectCodec
+
+projectToFields :: Project -> ProjectFields
+projectToFields p =
+  ProjectFields
+    { pfName = _projectName p,
+      pfInceptionDate = _inceptionDate p,
+      pfInitiator = _initiator p,
+      pfDepf = _depf (_depRules p)
+    }
 
 -- | Project response for GET /projects/:pid (flat project fields)
 data ProjectResponse = ProjectResponse
   { prProject :: Project
   }
 
-instance ToJSON ProjectResponse where
-  toJSON (ProjectResponse p) = projectToJSON p
+instance HasCodec ProjectResponse where
+  codec =
+    AC.dimapCodec (ProjectResponse . fieldsToProject) (projectToFields . prProject) $
+      codec @ProjectFields
+    where
+      fieldsToProject pf =
+        Project
+          { _projectName = pfName pf,
+            _inceptionDate = pfInceptionDate pf,
+            _initiator = pfInitiator pf,
+            _depRules = DepreciationRules (pfDepf pf) Nothing
+          }
+
+instance ToJSON ProjectResponse where toJSON = toJSONViaCodec
 
 -- | Project summary for GET /projects list (with projectId)
 data ProjectSummary = ProjectSummary
@@ -160,63 +227,100 @@ data ProjectSummary = ProjectSummary
     psProject :: Project
   }
 
-instance ToJSON ProjectSummary where
-  toJSON (ProjectSummary pid p) =
-    object
-      [ "projectId" .= pid,
-        "project" .= projectToJSON p
-      ]
+instance HasCodec ProjectSummary where
+  codec =
+    object "ProjectSummary" $
+      (\pid pf -> ProjectSummary pid (fieldsToProject pf))
+        <$> requiredField' "projectId" AC..= psProjectId
+        <*> requiredField' "project" AC..= (projectToFields . psProject)
+    where
+      fieldsToProject pf =
+        Project
+          { _projectName = pfName pf,
+            _inceptionDate = pfInceptionDate pf,
+            _initiator = pfInitiator pf,
+            _depRules = DepreciationRules (pfDepf pf) Nothing
+          }
+
+instance ToJSON ProjectSummary where toJSON = toJSONViaCodec
+
+-- | Contributor serialization helper
+data ContributorFields = ContributorFields
+  { cfUserId :: UserId,
+    cfUsername :: Text,
+    cfJoinedOn :: C.UTCTime,
+    cfLoggedHours :: Int64,
+    cfDepreciatedHours :: Int64,
+    cfRevenueShare :: RationalFields
+  }
+
+data RationalFields = RationalFields
+  { rfNumerator :: Integer,
+    rfDenominator :: Integer
+  }
+
+instance HasCodec RationalFields where
+  codec =
+    object "RationalFields" $
+      RationalFields
+        <$> requiredField' "numerator" AC..= rfNumerator
+        <*> requiredField' "denominator" AC..= rfDenominator
+
+instance HasCodec ContributorFields where
+  codec =
+    object "Contributor" $
+      ContributorFields
+        <$> requiredField' "userId" AC..= cfUserId
+        <*> requiredField' "username" AC..= cfUsername
+        <*> requiredField' "joinedOn" AC..= cfJoinedOn
+        <*> requiredField' "loggedHours" AC..= cfLoggedHours
+        <*> requiredField' "depreciatedHours" AC..= cfDepreciatedHours
+        <*> requiredField' "revenueShare" AC..= cfRevenueShare
+
+contributorToFields :: Contributor -> ContributorFields
+contributorToFields c =
+  ContributorFields
+    { cfUserId = _cUserId c,
+      cfUsername = let UserName n = _cHandle c in n,
+      cfJoinedOn = _cJoinedOn c,
+      cfLoggedHours = let Hours h = _cLoggedHours c in h,
+      cfDepreciatedHours = let Hours h = _cDepreciatedHours c in h,
+      cfRevenueShare = RationalFields (numerator $ _cRevenueShare c) (denominator $ _cRevenueShare c)
+    }
 
 -- | Project detail response for GET /projects/:pid/detail
 data ProjectDetailResponse = ProjectDetailResponse
   { pdrDetail :: ProjectDetail
   }
 
-instance ToJSON ProjectDetailResponse where
-  toJSON (ProjectDetailResponse detail) =
-    object
-      [ "project" .= projectToJSON (_pdProject detail),
-        "contributors" .= (M.elems $ fmap contributorToJSON (_pdContributors detail))
-      ]
+instance HasCodec ProjectDetailResponse where
+  codec =
+    object "ProjectDetailResponse" $
+      (\pf cs -> ProjectDetailResponse (ProjectDetail (fieldsToProject pf) (rebuildContributorMap cs)))
+        <$> requiredField' "project" AC..= (projectToFields . _pdProject . pdrDetail)
+        <*> requiredField' "contributors" AC..= (fmap contributorToFields . M.elems . _pdContributors . pdrDetail)
+    where
+      fieldsToProject pf =
+        Project
+          { _projectName = pfName pf,
+            _inceptionDate = pfInceptionDate pf,
+            _initiator = pfInitiator pf,
+            _depRules = DepreciationRules (pfDepf pf) Nothing
+          }
+      rebuildContributorMap :: [ContributorFields] -> M.Map UserId Contributor
+      rebuildContributorMap =
+        M.fromList . fmap (\cf -> (cfUserId cf, fieldsToContributor cf))
+      fieldsToContributor cf =
+        Contributor
+          { _cUserId = cfUserId cf,
+            _cHandle = UserName (cfUsername cf),
+            _cJoinedOn = cfJoinedOn cf,
+            _cLoggedHours = Hours (cfLoggedHours cf),
+            _cDepreciatedHours = Hours (cfDepreciatedHours cf),
+            _cRevenueShare = rfNumerator (cfRevenueShare cf) % rfDenominator (cfRevenueShare cf)
+          }
 
---------------------------------------------------------------------------------
--- JSON serialization helpers
---------------------------------------------------------------------------------
-
--- | Serialize a Project to JSON
-projectToJSON :: Project -> Value
-projectToJSON p =
-  object
-    [ "projectName" .= _projectName p,
-      "inceptionDate" .= _inceptionDate p,
-      "initiator" .= (let UserId u = _initiator p in UUID.toText u),
-      "depf" .= depfToJSON (_depf $ _depRules p)
-    ]
-
--- | Serialize a DepreciationFunction to JSON
-depfToJSON :: DepreciationFunction -> Value
-depfToJSON = \case
-  LinearDepreciation undep dep ->
-    object
-      [ "type" .= ("LinearDepreciation" :: Text),
-        "arguments" .= object ["undep" .= undep, "dep" .= dep]
-      ]
-
--- | Serialize a Contributor to JSON
-contributorToJSON :: Contributor -> Value
-contributorToJSON c =
-  object
-    [ "userId" .= _cUserId c,
-      "username" .= (let UserName n = _cHandle c in n),
-      "joinedOn" .= _cJoinedOn c,
-      "loggedHours" .= (let Hours h = _cLoggedHours c in h),
-      "depreciatedHours" .= (let Hours h = _cDepreciatedHours c in h),
-      "revenueShare"
-        .= object
-          [ "numerator" .= numerator (_cRevenueShare c),
-            "denominator" .= denominator (_cRevenueShare c)
-          ]
-    ]
+instance ToJSON ProjectDetailResponse where toJSON = toJSONViaCodec
 
 --------------------------------------------------------------------------------
 -- API Types

--- a/api/src/Aftok/API/Session.hs
+++ b/api/src/Aftok/API/Session.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Session API types for the Aftok API.
 module Aftok.API.Session
@@ -14,8 +16,10 @@ module Aftok.API.Session
 where
 
 import Aftok.API.Auth (AuthenticatedUser, LoginRequest)
-import Data.Aeson (ToJSON (..), (.=))
-import qualified Data.Aeson as A
+import Aftok.API.Codec ()
+import Autodocodec (HasCodec (..), object, requiredField', (.=))
+import Autodocodec.Aeson (toJSONViaCodec)
+import Data.Aeson (ToJSON (..))
 import Servant.API
 import Servant.Auth.Server (SetCookie)
 
@@ -40,9 +44,11 @@ data LoginCheckResponse = LoginCheckResponse
   }
   deriving (Show, Eq, Generic)
 
-instance ToJSON LoginCheckResponse where
-  toJSON (LoginCheckResponse li user) =
-    A.object
-      [ "loggedIn" .= li,
-        "user" .= user
-      ]
+instance HasCodec LoginCheckResponse where
+  codec =
+    object "LoginCheckResponse" $
+      LoginCheckResponse
+        <$> requiredField' "loggedIn" .= loggedIn
+        <*> requiredField' "user" .= loginUser
+
+instance ToJSON LoginCheckResponse where toJSON = toJSONViaCodec

--- a/api/src/Aftok/API/Types.hs
+++ b/api/src/Aftok/API/Types.hs
@@ -6,11 +6,13 @@
 -- instances for ID types used in URL parameters and JSON responses.
 module Aftok.API.Types () where
 
+import Aftok.API.Codec ()
 import Aftok.Auction (AuctionId (..))
 import Aftok.Billing (BillableId (..), SubscriptionId (..))
 import Aftok.Payments.Types (PaymentId (..))
 import Aftok.Types (ProjectId (..), UserId (..))
-import Data.Aeson (FromJSON (..), ToJSON (..), withText)
+import Autodocodec.Aeson (parseJSONViaCodec, toJSONViaCodec)
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import qualified Data.Thyme.Clock as C
 import Data.Thyme.Time.Core (fromThyme, toThyme)
 import qualified Data.Time as Time
@@ -62,59 +64,29 @@ instance ToHttpApiData C.UTCTime where
   toUrlPiece = toUrlPiece . fromThyme
 
 --------------------------------------------------------------------------------
--- JSON instances for ID types
+-- JSON instances for ID types (codec-derived)
 --------------------------------------------------------------------------------
 
-instance ToJSON UserId where
-  toJSON (UserId u) = toJSON $ UUID.toText u
+instance ToJSON UserId where toJSON = toJSONViaCodec
 
-instance FromJSON UserId where
-  parseJSON = withText "UserId" $ \t ->
-    case UUID.fromText t of
-      Nothing -> fail "Invalid UUID for UserId"
-      Just u -> pure $ UserId u
+instance FromJSON UserId where parseJSON = parseJSONViaCodec
 
-instance ToJSON ProjectId where
-  toJSON (ProjectId u) = toJSON $ UUID.toText u
+instance ToJSON ProjectId where toJSON = toJSONViaCodec
 
-instance FromJSON ProjectId where
-  parseJSON = withText "ProjectId" $ \t ->
-    case UUID.fromText t of
-      Nothing -> fail "Invalid UUID for ProjectId"
-      Just u -> pure $ ProjectId u
+instance FromJSON ProjectId where parseJSON = parseJSONViaCodec
 
-instance ToJSON BillableId where
-  toJSON (BillableId u) = toJSON $ UUID.toText u
+instance ToJSON BillableId where toJSON = toJSONViaCodec
 
-instance FromJSON BillableId where
-  parseJSON = withText "BillableId" $ \t ->
-    case UUID.fromText t of
-      Nothing -> fail "Invalid UUID for BillableId"
-      Just u -> pure $ BillableId u
+instance FromJSON BillableId where parseJSON = parseJSONViaCodec
 
-instance ToJSON SubscriptionId where
-  toJSON (SubscriptionId u) = toJSON $ UUID.toText u
+instance ToJSON SubscriptionId where toJSON = toJSONViaCodec
 
-instance FromJSON SubscriptionId where
-  parseJSON = withText "SubscriptionId" $ \t ->
-    case UUID.fromText t of
-      Nothing -> fail "Invalid UUID for SubscriptionId"
-      Just u -> pure $ SubscriptionId u
+instance FromJSON SubscriptionId where parseJSON = parseJSONViaCodec
 
-instance ToJSON AuctionId where
-  toJSON (AuctionId u) = toJSON $ UUID.toText u
+instance ToJSON AuctionId where toJSON = toJSONViaCodec
 
-instance FromJSON AuctionId where
-  parseJSON = withText "AuctionId" $ \t ->
-    case UUID.fromText t of
-      Nothing -> fail "Invalid UUID for AuctionId"
-      Just u -> pure $ AuctionId u
+instance FromJSON AuctionId where parseJSON = parseJSONViaCodec
 
-instance ToJSON PaymentId where
-  toJSON (PaymentId u) = toJSON $ UUID.toText u
+instance ToJSON PaymentId where toJSON = toJSONViaCodec
 
-instance FromJSON PaymentId where
-  parseJSON = withText "PaymentId" $ \t ->
-    case UUID.fromText t of
-      Nothing -> fail "Invalid UUID for PaymentId"
-      Just u -> pure $ PaymentId u
+instance FromJSON PaymentId where parseJSON = parseJSONViaCodec

--- a/api/src/Aftok/API/Users.hs
+++ b/api/src/Aftok/API/Users.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Users API types for the Aftok API.
 module Aftok.API.Users
@@ -34,6 +36,7 @@ module Aftok.API.Users
   )
 where
 
+import Aftok.API.Codec ()
 import Aftok.API.Types ()
 import Aftok.Project (InvitationCode, parseInvCode)
 import Aftok.Types
@@ -42,13 +45,15 @@ import Aftok.Types
     UserId,
     UserName (..),
   )
+import Autodocodec (HasCodec (..), object, optionalField', requiredField')
+import qualified Autodocodec as AC
+import Autodocodec.Aeson (parseJSONViaCodec, toJSONViaCodec)
 import Control.Lens (makeLenses)
 import Data.Aeson
   ( FromJSON (..),
     ToJSON (..),
     (.:),
     (.:?),
-    (.=),
   )
 import qualified Data.Aeson as A
 import Servant.API
@@ -59,11 +64,17 @@ import Servant.API
 
 -- | Registration response
 data RegisterResponse = RegisterResponse
-  { userId :: UserId
+  { rrUserId :: UserId
   }
   deriving (Generic)
 
-instance ToJSON RegisterResponse
+instance HasCodec RegisterResponse where
+  codec =
+    object "RegisterResponse" $
+      RegisterResponse
+        <$> requiredField' "userId" AC..= rrUserId
+
+instance ToJSON RegisterResponse where toJSON = toJSONViaCodec
 
 -- | Address validation error
 data AddressInvalid = AddressInvalid
@@ -120,11 +131,11 @@ data RegisterError
 instance ToJSON RegisterError where
   toJSON = \case
     RegParseError msg ->
-      A.object ["parseError" .= msg]
+      A.object ["parseError" A..= msg]
     RegCaptchaError e ->
-      A.object ["captchaError" .= (show e :: Text)]
+      A.object ["captchaError" A..= (show e :: Text)]
     RegZAddrError zerr ->
-      A.object ["zaddrError" .= (show zerr :: Text)]
+      A.object ["zaddrError" A..= (show zerr :: Text)]
 
 -- | Username check response
 data UsernameCheckResponse = UsernameCheckResponse
@@ -133,7 +144,14 @@ data UsernameCheckResponse = UsernameCheckResponse
   }
   deriving (Show, Eq, Generic)
 
-instance ToJSON UsernameCheckResponse
+instance HasCodec UsernameCheckResponse where
+  codec =
+    object "UsernameCheckResponse" $
+      UsernameCheckResponse
+        <$> requiredField' "usernameAvailable" AC..= usernameAvailable
+        <*> optionalField' "usernameMessage" AC..= usernameMessage
+
+instance ToJSON UsernameCheckResponse where toJSON = toJSONViaCodec
 
 -- | Z-address check response
 data ZAddrCheckResponse = ZAddrCheckResponse
@@ -142,7 +160,14 @@ data ZAddrCheckResponse = ZAddrCheckResponse
   }
   deriving (Show, Eq, Generic)
 
-instance ToJSON ZAddrCheckResponse
+instance HasCodec ZAddrCheckResponse where
+  codec =
+    object "ZAddrCheckResponse" $
+      ZAddrCheckResponse
+        <$> requiredField' "zaddrValid" AC..= zaddrValid
+        <*> optionalField' "zaddrMessage" AC..= zaddrMessage
+
+instance ToJSON ZAddrCheckResponse where toJSON = toJSONViaCodec
 
 -- | Captcha errors
 data CaptchaError
@@ -184,12 +209,14 @@ data AccountSettingsResponse = AccountSettingsResponse
   }
   deriving (Show, Eq, Generic)
 
-instance ToJSON AccountSettingsResponse where
-  toJSON (AccountSettingsResponse uname zaddr) =
-    A.object
-      [ "username" .= uname,
-        "zcashAddress" .= zaddr
-      ]
+instance HasCodec AccountSettingsResponse where
+  codec =
+    object "AccountSettingsResponse" $
+      AccountSettingsResponse
+        <$> requiredField' "username" AC..= asrUsername
+        <*> optionalField' "zcashAddress" AC..= asrZcashAddress
+
+instance ToJSON AccountSettingsResponse where toJSON = toJSONViaCodec
 
 -- | Set payment address request
 data SetPaymentAddressRequest = SetPaymentAddressRequest
@@ -197,10 +224,13 @@ data SetPaymentAddressRequest = SetPaymentAddressRequest
   }
   deriving (Show, Eq, Generic)
 
-instance FromJSON SetPaymentAddressRequest where
-  parseJSON (A.Object v) =
-    SetPaymentAddressRequest <$> v .: "zcashAddress"
-  parseJSON _ = mzero
+instance HasCodec SetPaymentAddressRequest where
+  codec =
+    object "SetPaymentAddressRequest" $
+      SetPaymentAddressRequest
+        <$> requiredField' "zcashAddress" AC..= sparZcashAddress
+
+instance FromJSON SetPaymentAddressRequest where parseJSON = parseJSONViaCodec
 
 --------------------------------------------------------------------------------
 -- API Types

--- a/api/src/Aftok/API/WorkLog.hs
+++ b/api/src/Aftok/API/WorkLog.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | WorkLog API types for the Aftok API.
 module Aftok.API.WorkLog
@@ -23,26 +25,23 @@ module Aftok.API.WorkLog
   )
 where
 
+import Aftok.API.Codec ()
 import Aftok.API.Types ()
-import Aftok.Json (creditToJSON, parseCreditToV2)
-import Aftok.TimeLog (AmendmentId (..), EventId (..), LogEvent (..), eventName, eventTime)
+import Aftok.Json (parseCreditToV2)
+import Aftok.TimeLog (AmendmentId (..), EventId (..), LogEvent (..))
 import Aftok.Types (CreditTo (..), ProjectId, UserId)
-import Control.Lens ((^.))
+import Autodocodec (HasCodec (..), object, optionalField', requiredField')
+import qualified Autodocodec as AC
+import Autodocodec.Aeson (parseJSONViaCodec, toJSONViaCodec)
 import Data.Aeson
   ( FromJSON (..),
     ToJSON (..),
     Value (Object),
-    object,
     (.:),
-    (.:?),
-    (.=),
   )
-import Data.Aeson.Key (fromText)
-import Data.Aeson.Types (Pair)
 import qualified Data.Text as T
 import qualified Data.Thyme.Clock as C
 import Data.Thyme.Format.Aeson ()
-import qualified Data.UUID as UUID
 import Servant.API
 
 -- | WorkLog API for user-specific project operations
@@ -77,12 +76,14 @@ data LogStartRequest = LogStartRequest
   }
   deriving (Generic)
 
-instance FromJSON LogStartRequest where
-  parseJSON (Object o) = do
-    creditTo' <- o .:? "creditTo" >>= maybe (pure Nothing) (fmap Just . parseCreditToV2)
-    eventMeta' <- o .:? "eventMeta"
-    pure $ LogStartRequest creditTo' eventMeta'
-  parseJSON _ = mzero
+instance FromJSON LogStartRequest where parseJSON = parseJSONViaCodec
+
+instance HasCodec LogStartRequest where
+  codec =
+    object "LogStartRequest" $
+      LogStartRequest
+        <$> optionalField' "creditTo" AC..= lsrCreditTo
+        <*> optionalField' "eventMeta" AC..= lsrEventMeta
 
 -- | Log end request
 data LogEndRequest = LogEndRequest
@@ -91,12 +92,14 @@ data LogEndRequest = LogEndRequest
   }
   deriving (Generic)
 
-instance FromJSON LogEndRequest where
-  parseJSON (Object o) = do
-    creditTo' <- o .:? "creditTo" >>= maybe (pure Nothing) (fmap Just . parseCreditToV2)
-    eventMeta' <- o .:? "eventMeta"
-    pure $ LogEndRequest creditTo' eventMeta'
-  parseJSON _ = mzero
+instance FromJSON LogEndRequest where parseJSON = parseJSONViaCodec
+
+instance HasCodec LogEndRequest where
+  codec =
+    object "LogEndRequest" $
+      LogEndRequest
+        <$> optionalField' "creditTo" AC..= lerCreditTo
+        <*> optionalField' "eventMeta" AC..= lerEventMeta
 
 -- | Event amendment request
 data EventAmendmentRequest = EventAmendmentRequest
@@ -135,13 +138,18 @@ data ExtendedLogEntryResponse = ExtendedLogEntryResponse
     elrEventMeta :: Maybe Value
   }
 
-instance ToJSON ExtendedLogEntryResponse where
-  toJSON r =
-    object $
-      [ "projectId" .= elrProjectId r,
-        "loggedBy" .= elrLoggedBy r
-      ]
-        <> keyedLogEntryFields (elrEventId r) (elrCreditTo r) (elrEvent r) (elrEventMeta r)
+instance HasCodec ExtendedLogEntryResponse where
+  codec =
+    object "ExtendedLogEntryResponse" $
+      ExtendedLogEntryResponse
+        <$> requiredField' "projectId" AC..= elrProjectId
+        <*> requiredField' "loggedBy" AC..= elrLoggedBy
+        <*> requiredField' "eventId" AC..= elrEventId
+        <*> requiredField' "creditTo" AC..= elrCreditTo
+        <*> requiredField' "event" AC..= elrEvent
+        <*> requiredField' "eventMeta" AC..= elrEventMeta
+
+instance ToJSON ExtendedLogEntryResponse where toJSON = toJSONViaCodec
 
 -- | Response for events list items
 data KeyedLogEntryResponse = KeyedLogEntryResponse
@@ -151,17 +159,29 @@ data KeyedLogEntryResponse = KeyedLogEntryResponse
     klrEventMeta :: Maybe Value
   }
 
-instance ToJSON KeyedLogEntryResponse where
-  toJSON r =
-    object $ keyedLogEntryFields (klrEventId r) (klrCreditTo r) (klrEvent r) (klrEventMeta r)
+instance HasCodec KeyedLogEntryResponse where
+  codec =
+    object "KeyedLogEntryResponse" $
+      KeyedLogEntryResponse
+        <$> requiredField' "eventId" AC..= klrEventId
+        <*> requiredField' "creditTo" AC..= klrCreditTo
+        <*> requiredField' "event" AC..= klrEvent
+        <*> requiredField' "eventMeta" AC..= klrEventMeta
+
+instance ToJSON KeyedLogEntryResponse where toJSON = toJSONViaCodec
 
 -- | Work index response
 data WorkIndexResponse = WorkIndexResponse
   { wirWorkIndex :: [WorkIndexEntry]
   }
 
-instance ToJSON WorkIndexResponse where
-  toJSON r = object ["workIndex" .= wirWorkIndex r]
+instance HasCodec WorkIndexResponse where
+  codec =
+    object "WorkIndexResponse" $
+      WorkIndexResponse
+        <$> requiredField' "workIndex" AC..= wirWorkIndex
+
+instance ToJSON WorkIndexResponse where toJSON = toJSONViaCodec
 
 -- | Work index entry (per credit-to)
 data WorkIndexEntry = WorkIndexEntry
@@ -169,12 +189,14 @@ data WorkIndexEntry = WorkIndexEntry
     wieIntervals :: [IntervalResponse]
   }
 
-instance ToJSON WorkIndexEntry where
-  toJSON r =
-    object
-      [ "creditTo" .= creditToJSON (wieCreditTo r),
-        "intervals" .= wieIntervals r
-      ]
+instance HasCodec WorkIndexEntry where
+  codec =
+    object "WorkIndexEntry" $
+      WorkIndexEntry
+        <$> requiredField' "creditTo" AC..= wieCreditTo
+        <*> requiredField' "intervals" AC..= wieIntervals
+
+instance ToJSON WorkIndexEntry where toJSON = toJSONViaCodec
 
 -- | Interval in the work index
 data IntervalResponse = IntervalResponse
@@ -182,8 +204,14 @@ data IntervalResponse = IntervalResponse
     irEnd :: KeyedLogEntryResponse
   }
 
-instance ToJSON IntervalResponse where
-  toJSON r = object ["start" .= irStart r, "end" .= irEnd r]
+instance HasCodec IntervalResponse where
+  codec =
+    object "IntervalResponse" $
+      IntervalResponse
+        <$> requiredField' "start" AC..= irStart
+        <*> requiredField' "end" AC..= irEnd
+
+instance ToJSON IntervalResponse where toJSON = toJSONViaCodec
 
 -- | Event amendment result
 data AmendEventResponse = AmendEventResponse
@@ -191,27 +219,11 @@ data AmendEventResponse = AmendEventResponse
     aerAmendmentId :: AmendmentId
   }
 
-instance ToJSON AmendEventResponse where
-  toJSON r =
-    object
-      [ "replacement_event" .= (let EventId u = aerReplacementEvent r in UUID.toText u),
-        "amendment_id" .= (let AmendmentId u = aerAmendmentId r in UUID.toText u)
-      ]
+instance HasCodec AmendEventResponse where
+  codec =
+    object "AmendEventResponse" $
+      AmendEventResponse
+        <$> requiredField' "replacement_event" AC..= aerReplacementEvent
+        <*> requiredField' "amendment_id" AC..= aerAmendmentId
 
---------------------------------------------------------------------------------
--- Serialization Helpers
---------------------------------------------------------------------------------
-
--- | Serialize a log event to JSON
-logEventToJSON :: LogEvent -> Value
-logEventToJSON ev =
-  object [fromText (eventName ev) .= object ["eventTime" .= (ev ^. eventTime)]]
-
--- | Common fields for keyed log entries
-keyedLogEntryFields :: EventId -> CreditTo -> LogEvent -> Maybe Value -> [Pair]
-keyedLogEntryFields eid ct ev meta =
-  [ "eventId" .= (let EventId u = eid in UUID.toText u),
-    "creditTo" .= creditToJSON ct,
-    "event" .= logEventToJSON ev,
-    "eventMeta" .= meta
-  ]
+instance ToJSON AmendEventResponse where toJSON = toJSONViaCodec


### PR DESCRIPTION
Replace ~35 freeformObject OpenAPI schema instances with autodocodec-based codecs that serve as a single source of truth for JSON serialization, deserialization, and OpenAPI schema generation.

- Add autodocodec and autodocodec-openapi3 dependencies
- Create Aftok.API.Codec with HasCodec orphan instances for core types (UserId, ProjectId, CreditTo, DepreciationFunction, LogEvent, etc.)
- Add HasCodec instances to all API request/response types
- Replace manual ToJSON/FromJSON with toJSONViaCodec/parseJSONViaCodec
- Replace freeformObject ToSchema instances with declareNamedSchemaViaCodec
- Remove redundant API-layer serialization helpers

JSON wire format is preserved exactly; core library and database layer are unchanged.