### PR TITLE
Add GitHub PR time tracking via webhook integration

### DIFF
--- a/api/aftok-api.cabal
+++ b/api/aftok-api.cabal
@@ -41,6 +41,7 @@ library
     Aftok.API.Payments
     Aftok.API.PasswordReset
     Aftok.API.Config
+    Aftok.API.GitHub
     Aftok.API.OpenApi
 
   build-depends:

--- a/api/src/Aftok/API.hs
+++ b/api/src/Aftok/API.hs
@@ -20,6 +20,7 @@ module Aftok.API
     module Aftok.API.Payments,
     module Aftok.API.PasswordReset,
     module Aftok.API.Config,
+    module Aftok.API.GitHub,
 
     -- * Auth Types
     module Aftok.API.Auth,
@@ -33,6 +34,7 @@ import Aftok.API.Auctions
 import Aftok.API.Auth
 import Aftok.API.Billing
 import Aftok.API.Config
+import Aftok.API.GitHub
 import Aftok.API.PasswordReset
 import Aftok.API.Payments
 import Aftok.API.Projects
@@ -57,6 +59,10 @@ type VersionedAPI =
     :<|> PasswordResetAPI
     -- Client configuration endpoint (public)
     :<|> ConfigAPI
+    -- GitHub webhook endpoint (public, signature-verified)
+    :<|> GitHubWebhookAPI
+    -- GitHub OAuth callback endpoint (public, auth via state JWT)
+    :<|> GitHubOAuthCallbackAPI
     -- Protected endpoints (auth required)
     :<|> AftokAuth :> ProtectedAPI
 
@@ -76,6 +82,8 @@ type ProtectedAPI =
     :<|> ProtectedUsersAPI
     -- Session operations (login check)
     :<|> ProtectedSessionAPI
+    -- GitHub username linking (user profile)
+    :<|> "user" :> GitHubUserAPI
 
 -- | Proxy for the API (used for serving and client generation)
 aftokAPI :: Proxy AftokAPI

--- a/api/src/Aftok/API/Codec.hs
+++ b/api/src/Aftok/API/Codec.hs
@@ -15,6 +15,9 @@ import Aftok.Types
   ( AccountId (..),
     CreditTo (..),
     DepreciationFunction (..),
+    GitHubRepoLinkId (..),
+    GitHubUsername (..),
+    GitHubWebhookEventId (..),
     ProjectId (..),
     UserId (..),
     UserName (..),
@@ -77,6 +80,12 @@ instance HasCodec PaymentRequestId where
 instance HasCodec PaymentId where
   codec = uuidCodec (\(PaymentId u) -> u) PaymentId "PaymentId UUID"
 
+instance HasCodec GitHubRepoLinkId where
+  codec = uuidCodec (\(GitHubRepoLinkId u) -> u) GitHubRepoLinkId "GitHubRepoLinkId UUID"
+
+instance HasCodec GitHubWebhookEventId where
+  codec = uuidCodec (\(GitHubWebhookEventId u) -> u) GitHubWebhookEventId "GitHubWebhookEventId UUID"
+
 --------------------------------------------------------------------------------
 -- Thyme UTCTime
 --------------------------------------------------------------------------------
@@ -90,6 +99,9 @@ instance HasCodec C.UTCTime where
 
 instance HasCodec UserName where
   codec = dimapCodec UserName (\(UserName t) -> t) codec
+
+instance HasCodec GitHubUsername where
+  codec = dimapCodec GitHubUsername (\(GitHubUsername t) -> t) codec
 
 --------------------------------------------------------------------------------
 -- CreditTo

--- a/api/src/Aftok/API/GitHub.hs
+++ b/api/src/Aftok/API/GitHub.hs
@@ -1,0 +1,180 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeOperators #-}
+
+-- | GitHub integration API types for the Aftok API.
+module Aftok.API.GitHub
+  ( -- * API Types
+    GitHubWebhookAPI,
+    GitHubProjectAPI,
+    GitHubUserAPI,
+    GitHubOAuthCallbackAPI,
+
+    -- * Request/Response Types
+    LinkRepoRequest (..),
+    LinkRepoResponse (..),
+    RepoLinkInfo (..),
+    GitHubOAuthInitResponse (..),
+    GitHubUsernameResponse (..),
+    GitHubWebhookPayload (..),
+  )
+where
+
+import Aftok.API.Codec ()
+import Aftok.Types (GitHubRepoLinkId (..))
+import Autodocodec (HasCodec (..), object, optionalField', requiredField')
+import qualified Autodocodec as AC
+import Autodocodec.Aeson (parseJSONViaCodec, toJSONViaCodec)
+import Data.Aeson
+  ( FromJSON (..),
+    ToJSON (..),
+  )
+import qualified Data.Thyme.Clock as C
+import Data.UUID (UUID)
+import Servant.API
+
+--------------------------------------------------------------------------------
+-- Request/Response Types
+--------------------------------------------------------------------------------
+
+-- | Request to link a GitHub repository to a project
+data LinkRepoRequest = LinkRepoRequest
+  { lrrOwner :: Text,
+    lrrRepo :: Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance HasCodec LinkRepoRequest where
+  codec =
+    object "LinkRepoRequest" $
+      LinkRepoRequest
+        <$> requiredField' "owner" AC..= lrrOwner
+        <*> requiredField' "repo" AC..= lrrRepo
+
+instance FromJSON LinkRepoRequest where parseJSON = parseJSONViaCodec
+
+-- | Response when linking a repository
+data LinkRepoResponse = LinkRepoResponse
+  { lrLinkId :: GitHubRepoLinkId,
+    lrWebhookSecret :: Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance HasCodec LinkRepoResponse where
+  codec =
+    object "LinkRepoResponse" $
+      LinkRepoResponse
+        <$> requiredField' "linkId" AC..= lrLinkId
+        <*> requiredField' "webhookSecret" AC..= lrWebhookSecret
+
+instance ToJSON LinkRepoResponse where toJSON = toJSONViaCodec
+
+-- | Information about a linked repository
+data RepoLinkInfo = RepoLinkInfo
+  { rliId :: GitHubRepoLinkId,
+    rliOwner :: Text,
+    rliRepo :: Text,
+    rliCreatedAt :: C.UTCTime
+  }
+  deriving (Show, Eq, Generic)
+
+instance HasCodec RepoLinkInfo where
+  codec =
+    object "RepoLinkInfo" $
+      RepoLinkInfo
+        <$> requiredField' "id" AC..= rliId
+        <*> requiredField' "owner" AC..= rliOwner
+        <*> requiredField' "repo" AC..= rliRepo
+        <*> requiredField' "createdAt" AC..= rliCreatedAt
+
+instance ToJSON RepoLinkInfo where toJSON = toJSONViaCodec
+
+-- | Response containing the GitHub OAuth authorization URL
+data GitHubOAuthInitResponse = GitHubOAuthInitResponse
+  { goirAuthUrl :: Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance HasCodec GitHubOAuthInitResponse where
+  codec =
+    object "GitHubOAuthInitResponse" $
+      GitHubOAuthInitResponse
+        <$> requiredField' "authUrl" AC..= goirAuthUrl
+
+instance ToJSON GitHubOAuthInitResponse where toJSON = toJSONViaCodec
+
+-- | Response with GitHub username info
+data GitHubUsernameResponse = GitHubUsernameResponse
+  { ghurUsername :: Maybe Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance HasCodec GitHubUsernameResponse where
+  codec =
+    object "GitHubUsernameResponse" $
+      GitHubUsernameResponse
+        <$> optionalField' "username" AC..= ghurUsername
+
+instance ToJSON GitHubUsernameResponse where toJSON = toJSONViaCodec
+
+-- | Raw webhook request body. Wrapped to permit per-newtype OpenAPI
+-- 'ToSchema' (openapi3 cannot derive a schema for bare 'ByteString'). The
+-- HMAC verification depends on byte-identical comparison with what
+-- GitHub signed, so the handler MUST treat this body as opaque bytes
+-- (not parsed-and-re-encoded JSON) when computing the signature.
+newtype GitHubWebhookPayload = GitHubWebhookPayload {unGitHubWebhookPayload :: ByteString}
+  deriving (MimeRender OctetStream, MimeUnrender OctetStream)
+
+--------------------------------------------------------------------------------
+-- API Types
+--------------------------------------------------------------------------------
+
+-- | Public GitHub webhook endpoint (no auth, uses signature verification)
+--
+-- The request body is consumed as raw bytes; HMAC verification depends on
+-- byte-identical comparison with what GitHub signed. JSON parsing happens
+-- in the handler after signature verification succeeds.
+type GitHubWebhookAPI =
+  "webhooks"
+    :> "github"
+    :> Header "Content-Type" Text
+    :> Header "X-GitHub-Event" Text
+    :> Header "X-GitHub-Delivery" Text
+    :> Header "X-Hub-Signature-256" Text
+    :> ReqBody '[OctetStream] GitHubWebhookPayload
+    :> Post '[JSON] NoContent
+
+-- | Project-level GitHub management API (protected)
+type GitHubProjectAPI =
+  "github"
+    :> "repos"
+    :> ( -- GET /projects/:projectId/github/repos - List linked repos
+         Get '[JSON] [RepoLinkInfo]
+           -- POST /projects/:projectId/github/repos - Link a repo
+           :<|> ReqBody '[JSON] LinkRepoRequest :> Post '[JSON] LinkRepoResponse
+           -- DELETE /projects/:projectId/github/repos/:id - Unlink a repo
+           :<|> Capture "linkId" UUID :> Delete '[JSON] NoContent
+       )
+
+-- | User-level GitHub username linking API (protected)
+type GitHubUserAPI =
+  "github"
+    :> ( -- GET /user/github - Get linked GitHub username
+         Get '[JSON] GitHubUsernameResponse
+           -- POST /user/github/link - Initiate GitHub OAuth flow
+           :<|> "link" :> Post '[JSON] GitHubOAuthInitResponse
+           -- DELETE /user/github - Unlink GitHub username
+           :<|> Delete '[JSON] NoContent
+       )
+
+-- | GitHub OAuth callback endpoint (public, auth via state JWT)
+type GitHubOAuthCallbackAPI =
+  "user"
+    :> "github"
+    :> "callback"
+    :> QueryParam "code" Text
+    :> QueryParam "state" Text
+    :> QueryParam "error" Text
+    :> Verb 'GET 302 '[PlainText] (Headers '[Header "Location" Text] NoContent)

--- a/api/src/Aftok/API/OpenApi.hs
+++ b/api/src/Aftok/API/OpenApi.hs
@@ -24,6 +24,14 @@ import Aftok.API.Billing
   )
 import Aftok.API.Codec ()
 import Aftok.API.Config (ClientConfig)
+import Aftok.API.GitHub
+  ( GitHubOAuthInitResponse,
+    GitHubUsernameResponse,
+    GitHubWebhookPayload (..),
+    LinkRepoRequest,
+    LinkRepoResponse,
+    RepoLinkInfo,
+  )
 import Aftok.API.PasswordReset
   ( PasswordResetConfirm,
     PasswordResetRequest,
@@ -63,7 +71,7 @@ import Aftok.API.WorkLog
 import Aftok.Auction (AuctionId (..))
 import Aftok.Billing (BillableId (..), SubscriptionId (..))
 import Aftok.Payments.Types (PaymentId (..))
-import Aftok.Types (ProjectId (..), UserId (..))
+import Aftok.Types (GitHubRepoLinkId (..), ProjectId (..), UserId (..))
 import Autodocodec.OpenAPI (declareNamedSchemaViaCodec)
 import Control.Lens ((.~), (?~))
 import qualified Data.Aeson as A
@@ -166,6 +174,10 @@ instance ToSchema A.Value where
 -- | BIP70 binary data wrapper
 instance ToSchema BIP70Data where
   declareNamedSchema _ = pure $ NamedSchema (Just "BIP70Data") OA.binarySchema
+
+instance ToSchema GitHubWebhookPayload where
+  declareNamedSchema _ =
+    pure $ NamedSchema (Just "GitHubWebhookPayload") OA.binarySchema
 
 --------------------------------------------------------------------------------
 -- ToSchema instances for API request/response types (codec-derived)
@@ -318,4 +330,23 @@ instance ToSchema PasswordResetConfirm where
 
 -- Config
 instance ToSchema ClientConfig where
+  declareNamedSchema = declareNamedSchemaViaCodec
+
+-- GitHub
+instance ToSchema GitHubRepoLinkId where
+  declareNamedSchema = declareNamedSchemaViaCodec
+
+instance ToSchema LinkRepoRequest where
+  declareNamedSchema = declareNamedSchemaViaCodec
+
+instance ToSchema LinkRepoResponse where
+  declareNamedSchema = declareNamedSchemaViaCodec
+
+instance ToSchema RepoLinkInfo where
+  declareNamedSchema = declareNamedSchemaViaCodec
+
+instance ToSchema GitHubOAuthInitResponse where
+  declareNamedSchema = declareNamedSchemaViaCodec
+
+instance ToSchema GitHubUsernameResponse where
   declareNamedSchema = declareNamedSchemaViaCodec

--- a/api/src/Aftok/API/Projects.hs
+++ b/api/src/Aftok/API/Projects.hs
@@ -40,6 +40,7 @@ where
 import Aftok.API.Auctions (ProjectAuctionsAPI)
 import Aftok.API.Billing (ProjectBillablesAPI)
 import Aftok.API.Codec ()
+import Aftok.API.GitHub (GitHubProjectAPI)
 import Aftok.API.Types ()
 import qualified Aftok.Currency.Zcash.Zip321 as Zip321
 import Aftok.Project (Project (..))
@@ -356,3 +357,5 @@ type SingleProjectAPI =
     :<|> "auctions" :> ProjectAuctionsAPI
     -- GET/POST /projects/:projectId/billables
     :<|> "billables" :> ProjectBillablesAPI
+    -- GitHub repo management
+    :<|> GitHubProjectAPI

--- a/api/src/Aftok/API/Types.hs
+++ b/api/src/Aftok/API/Types.hs
@@ -10,7 +10,7 @@ import Aftok.API.Codec ()
 import Aftok.Auction (AuctionId (..))
 import Aftok.Billing (BillableId (..), SubscriptionId (..))
 import Aftok.Payments.Types (PaymentId (..))
-import Aftok.Types (ProjectId (..), UserId (..))
+import Aftok.Types (GitHubRepoLinkId (..), GitHubUsername (..), GitHubWebhookEventId (..), ProjectId (..), UserId (..))
 import Autodocodec.Aeson (parseJSONViaCodec, toJSONViaCodec)
 import Data.Aeson (FromJSON (..), ToJSON (..))
 import qualified Data.Thyme.Clock as C
@@ -90,3 +90,15 @@ instance FromJSON AuctionId where parseJSON = parseJSONViaCodec
 instance ToJSON PaymentId where toJSON = toJSONViaCodec
 
 instance FromJSON PaymentId where parseJSON = parseJSONViaCodec
+
+instance ToJSON GitHubRepoLinkId where toJSON = toJSONViaCodec
+
+instance FromJSON GitHubRepoLinkId where parseJSON = parseJSONViaCodec
+
+instance ToJSON GitHubWebhookEventId where toJSON = toJSONViaCodec
+
+instance FromJSON GitHubWebhookEventId where parseJSON = parseJSONViaCodec
+
+instance ToJSON GitHubUsername where toJSON = toJSONViaCodec
+
+instance FromJSON GitHubUsername where parseJSON = parseJSONViaCodec

--- a/core/aftok.cabal
+++ b/core/aftok.cabal
@@ -29,6 +29,7 @@ common base-deps
     relude >= 1.1.0 && < 1.3,
     aeson >= 2.0.3 && < 2.3,
     attoparsec >= 0.14.4 && < 0.15,
+    base16-bytestring >= 1.0 && < 1.1,
     bifunctors >= 5.5.15 && < 5.7,
     bippy >= 0.3 && < 0.4,
     bytestring >= 0.11.4 && < 0.13,
@@ -36,6 +37,7 @@ common base-deps
     configurator >= 0.3.0 && < 0.4,
     containers >= 0.6.5 && < 0.8,
     cryptonite >= 0.30 && < 0.31,
+    memory >= 0.18 && < 0.19,
     either >= 5.0.2 && < 5.1,
     errors >= 2.3.0 && < 2.4,
     from-sum >= 0.2.3 && < 0.3,
@@ -86,12 +88,14 @@ library
     Aftok.Currency.Zcash.Payments
     Aftok.Currency.Zcash.Zip321
     Aftok.Database
+    Aftok.GitHub
     Aftok.Database.PostgreSQL
     Aftok.Database.PostgreSQL.Json
     Aftok.Database.PostgreSQL.Types
     Aftok.Database.PostgreSQL.Auctions
     Aftok.Database.PostgreSQL.Billing
     Aftok.Database.PostgreSQL.Events
+    Aftok.Database.PostgreSQL.GitHub
     Aftok.Database.PostgreSQL.PasswordReset
     Aftok.Database.PostgreSQL.Projects
     Aftok.Database.PostgreSQL.Users
@@ -136,6 +140,7 @@ Test-Suite spec
   other-modules:
     Aftok.AuctionSpec
     Aftok.Generators
+    Aftok.GitHubSpec
     Aftok.PaymentsSpec
     Aftok.Servant.ApiSpec
     Aftok.TimeLogSpec

--- a/core/lib/Aftok/Database.hs
+++ b/core/lib/Aftok/Database.hs
@@ -13,6 +13,10 @@ import Aftok.Billing as B
 import Aftok.Currency (Amount, Currency)
 import Aftok.Currency.Bitcoin.Payments (PaymentKey)
 import qualified Aftok.Currency.Zcash as Zcash
+import Aftok.GitHub
+  ( GitHubRepoLink,
+    GitHubWebhookEvent,
+  )
 import Aftok.Interval (RangeQuery)
 import Aftok.Password (PasswordHash)
 import Aftok.Payments.Types
@@ -35,6 +39,9 @@ import qualified Aftok.TimeLog as TL
 import Aftok.Types
   ( AccountId,
     Email,
+    GitHubRepoLinkId,
+    GitHubUsername,
+    GitHubWebhookEventId,
     PasswordResetToken,
     PasswordResetTokenId,
     ProjectId,
@@ -74,6 +81,7 @@ type InvitedUID = UserId
 data Limit = Limit Word32
 
 data DBOp a where
+  CreateUser :: User -> DBOp UserId
   CreateUserWithPassword :: User -> PasswordHash -> DBOp UserId
   FindUser :: UserId -> DBOp (Maybe User)
   FindUserProjectDetail :: UserId -> ProjectId -> DBOp (Maybe (User, C.UTCTime))
@@ -124,6 +132,19 @@ data DBOp a where
   -- Zcash address operations
   SetUserZcashAddress :: UserId -> Zcash.Address -> DBOp ()
   FindUserZcashAddress :: UserId -> DBOp (Maybe Zcash.Address)
+  -- GitHub integration operations
+  FindUserByGitHubUsername :: GitHubUsername -> DBOp (Maybe (UserId, User))
+  LinkGitHubUsername :: UserId -> GitHubUsername -> DBOp ()
+  UnlinkGitHubUsername :: UserId -> DBOp ()
+  GetUserGitHubUsername :: UserId -> DBOp (Maybe GitHubUsername)
+  CreateGitHubRepoLink :: GitHubRepoLink -> DBOp GitHubRepoLinkId
+  FindGitHubRepoLink :: Text -> Text -> DBOp (Maybe (GitHubRepoLinkId, GitHubRepoLink))
+  FindProjectGitHubRepoLinks :: ProjectId -> DBOp [(GitHubRepoLinkId, GitHubRepoLink)]
+  DeleteGitHubRepoLink :: GitHubRepoLinkId -> DBOp ()
+  RecordWebhookEvent :: GitHubRepoLinkId -> GitHubWebhookEvent -> DBOp GitHubWebhookEventId
+  ClaimWebhookDelivery :: GitHubRepoLinkId -> Text -> Text -> C.UTCTime -> DBOp (Maybe GitHubWebhookEventId)
+  FinalizeWebhookDelivery :: GitHubWebhookEventId -> GitHubWebhookEvent -> DBOp ()
+  IsDeliveryProcessed :: Text -> DBOp Bool
   RaiseDBError :: forall x y. DBError -> DBOp x -> DBOp y
 
 data InvitationError
@@ -167,6 +188,9 @@ raiseSubjectNotFound :: (MonadDB m) => DBOp y -> m x
 raiseSubjectNotFound op = liftdb $ RaiseDBError SubjectNotFound op
 
 -- User ops
+
+createUser :: (MonadDB m) => User -> m UserId
+createUser user = liftdb $ CreateUser user
 
 createUserWithPassword :: (MonadDB m) => User -> PasswordHash -> m UserId
 createUserWithPassword user pwd = liftdb $ CreateUserWithPassword user pwd
@@ -372,6 +396,56 @@ findSubscriptionUnpaidRequests = liftdb . FindSubscriptionUnpaidRequests
 
 findPayment :: (MonadDB m) => Currency a c -> PaymentRequestId -> MaybeT m (Payment c)
 findPayment currency prid = MaybeT $ (fmap snd . headMay) <$> liftdb (FindPayments currency prid)
+
+-- GitHub integration ops
+
+findUserByGitHubUsername :: (MonadDB m) => GitHubUsername -> MaybeT m (UserId, User)
+findUserByGitHubUsername = MaybeT . liftdb . FindUserByGitHubUsername
+
+linkGitHubUsername :: (MonadDB m) => UserId -> GitHubUsername -> m ()
+linkGitHubUsername uid ghUser = liftdb $ LinkGitHubUsername uid ghUser
+
+unlinkGitHubUsername :: (MonadDB m) => UserId -> m ()
+unlinkGitHubUsername uid = liftdb $ UnlinkGitHubUsername uid
+
+getUserGitHubUsername :: (MonadDB m) => UserId -> m (Maybe GitHubUsername)
+getUserGitHubUsername = liftdb . GetUserGitHubUsername
+
+createGitHubRepoLink :: (MonadDB m) => GitHubRepoLink -> m GitHubRepoLinkId
+createGitHubRepoLink = liftdb . CreateGitHubRepoLink
+
+findGitHubRepoLink :: (MonadDB m) => Text -> Text -> MaybeT m (GitHubRepoLinkId, GitHubRepoLink)
+findGitHubRepoLink owner repo = MaybeT . liftdb $ FindGitHubRepoLink owner repo
+
+findProjectGitHubRepoLinks :: (MonadDB m) => ProjectId -> m [(GitHubRepoLinkId, GitHubRepoLink)]
+findProjectGitHubRepoLinks = liftdb . FindProjectGitHubRepoLinks
+
+deleteGitHubRepoLink :: (MonadDB m) => GitHubRepoLinkId -> m ()
+deleteGitHubRepoLink = liftdb . DeleteGitHubRepoLink
+
+recordWebhookEvent :: (MonadDB m) => GitHubRepoLinkId -> GitHubWebhookEvent -> m GitHubWebhookEventId
+recordWebhookEvent linkId ev = liftdb $ RecordWebhookEvent linkId ev
+
+-- | Atomically claim a webhook delivery for processing. Returns the row id
+-- on first claim, or 'Nothing' if some other concurrent caller already
+-- inserted the row for the same delivery id. The companion
+-- 'finalizeWebhookDelivery' updates the row to its terminal state.
+claimWebhookDelivery ::
+  (MonadDB m) =>
+  GitHubRepoLinkId ->
+  Text ->
+  Text ->
+  C.UTCTime ->
+  m (Maybe GitHubWebhookEventId)
+claimWebhookDelivery linkId deliveryId eventType receivedAt =
+  liftdb $ ClaimWebhookDelivery linkId deliveryId eventType receivedAt
+
+-- | Finalize a previously claimed webhook delivery row.
+finalizeWebhookDelivery :: (MonadDB m) => GitHubWebhookEventId -> GitHubWebhookEvent -> m ()
+finalizeWebhookDelivery rowId ev = liftdb $ FinalizeWebhookDelivery rowId ev
+
+isDeliveryProcessed :: (MonadDB m) => Text -> m Bool
+isDeliveryProcessed = liftdb . IsDeliveryProcessed
 
 -- Auction ops
 

--- a/core/lib/Aftok/Database/PostgreSQL.hs
+++ b/core/lib/Aftok/Database/PostgreSQL.hs
@@ -14,6 +14,7 @@ import Aftok.Database
 import qualified Aftok.Database.PostgreSQL.Auctions as Q
 import qualified Aftok.Database.PostgreSQL.Billing as Q
 import qualified Aftok.Database.PostgreSQL.Events as Q
+import qualified Aftok.Database.PostgreSQL.GitHub as Q
 import qualified Aftok.Database.PostgreSQL.PasswordReset as Q
 import qualified Aftok.Database.PostgreSQL.Projects as Q
 import qualified Aftok.Database.PostgreSQL.Users as Q
@@ -53,6 +54,7 @@ pgEval =
     (ListAuctions pid rq l) -> Q.listAuctions pid rq l
     (CreateBid aucId bid) -> Q.createBid aucId bid
     (FindBids aucId) -> Q.findBids aucId
+    (CreateUser user') -> Q.createUser user'
     (CreateUserWithPassword user' pwd) -> Q.createUserWithPassword user' pwd
     (FindUser uid) -> Q.findUser uid
     (FindUserProjectDetail uid pid) -> Q.findUserProjectDetail uid pid
@@ -101,4 +103,18 @@ pgEval =
     -- Zcash address operations
     (SetUserZcashAddress uid addr) -> Q.setUserZcashAddress uid addr
     (FindUserZcashAddress uid) -> Q.findUserZcashAddress uid
+    -- GitHub integration operations
+    (FindUserByGitHubUsername ghUser) -> Q.findUserByGitHubUsername ghUser
+    (LinkGitHubUsername uid ghUser) -> Q.linkGitHubUsername uid ghUser
+    (UnlinkGitHubUsername uid) -> Q.unlinkGitHubUsername uid
+    (GetUserGitHubUsername uid) -> Q.getUserGitHubUsername uid
+    (CreateGitHubRepoLink link) -> Q.createGitHubRepoLink link
+    (FindGitHubRepoLink owner repo) -> Q.findGitHubRepoLink owner repo
+    (FindProjectGitHubRepoLinks pid) -> Q.findProjectGitHubRepoLinks pid
+    (DeleteGitHubRepoLink linkId) -> Q.deleteGitHubRepoLink linkId
+    (RecordWebhookEvent linkId ev) -> Q.recordWebhookEvent linkId ev
+    (ClaimWebhookDelivery linkId deliveryId eventType receivedAt) ->
+      Q.claimWebhookDelivery linkId deliveryId eventType receivedAt
+    (FinalizeWebhookDelivery rowId ev) -> Q.finalizeWebhookDelivery rowId ev
+    (IsDeliveryProcessed deliveryId) -> Q.isDeliveryProcessed deliveryId
     (RaiseDBError err _) -> lift . throwE $ err

--- a/core/lib/Aftok/Database/PostgreSQL/GitHub.hs
+++ b/core/lib/Aftok/Database/PostgreSQL/GitHub.hs
@@ -1,0 +1,222 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Aftok.Database.PostgreSQL.GitHub
+  ( -- * Repo link operations
+    createGitHubRepoLink,
+    findGitHubRepoLink,
+    findProjectGitHubRepoLinks,
+    deleteGitHubRepoLink,
+
+    -- * Webhook event tracking
+    recordWebhookEvent,
+    isDeliveryProcessed,
+    claimWebhookDelivery,
+    finalizeWebhookDelivery,
+  )
+where
+
+import Aftok.Database.PostgreSQL.Types
+  ( DBM,
+    idParser,
+    pexec,
+    pinsert,
+    pquery,
+    utcParser,
+  )
+import Aftok.GitHub
+  ( GitHubEventStatus (..),
+    GitHubRepoLink (..),
+    GitHubWebhookEvent (..),
+    repoLinkCreatedBy,
+    repoLinkOwner,
+    repoLinkProjectId,
+    repoLinkRepo,
+    repoLinkWebhookSecret,
+  )
+import Aftok.TimeLog (EventId (..))
+import Aftok.Types
+  ( GitHubRepoLinkId (..),
+    GitHubUsername (..),
+    GitHubWebhookEventId (..),
+    ProjectId (..),
+    UserId (..),
+    _ProjectId,
+    _UserId,
+  )
+import Control.Lens ((^.))
+import qualified Data.Thyme.Clock as C
+import Data.Thyme.Time.Core (fromThyme)
+import Database.PostgreSQL.Simple
+import Database.PostgreSQL.Simple.FromRow
+import Database.PostgreSQL.Simple.SqlQQ (sql)
+import Safe (headMay)
+
+-- | Create a new GitHub repo link
+createGitHubRepoLink :: GitHubRepoLink -> DBM GitHubRepoLinkId
+createGitHubRepoLink link =
+  pinsert
+    GitHubRepoLinkId
+    [sql| INSERT INTO github_repo_links (project_id, github_owner, github_repo, webhook_secret, created_by)
+          VALUES (?, ?, ?, ?, ?) RETURNING id |]
+    ( link ^. repoLinkProjectId . _ProjectId,
+      link ^. repoLinkOwner,
+      link ^. repoLinkRepo,
+      link ^. repoLinkWebhookSecret,
+      link ^. repoLinkCreatedBy . _UserId
+    )
+
+-- | Find a GitHub repo link by owner/repo
+findGitHubRepoLink :: Text -> Text -> DBM (Maybe (GitHubRepoLinkId, GitHubRepoLink))
+findGitHubRepoLink owner repo =
+  headMay
+    <$> pquery
+      repoLinkParser
+      [sql| SELECT id, project_id, github_owner, github_repo, webhook_secret, created_by, created_at
+            FROM github_repo_links
+            WHERE github_owner = ? AND github_repo = ? |]
+      (owner, repo)
+
+-- | Find all GitHub repo links for a project
+findProjectGitHubRepoLinks :: ProjectId -> DBM [(GitHubRepoLinkId, GitHubRepoLink)]
+findProjectGitHubRepoLinks (ProjectId pid) =
+  pquery
+    repoLinkParser
+    [sql| SELECT id, project_id, github_owner, github_repo, webhook_secret, created_by, created_at
+          FROM github_repo_links
+          WHERE project_id = ? |]
+    (Only pid)
+
+-- | Delete a GitHub repo link
+deleteGitHubRepoLink :: GitHubRepoLinkId -> DBM ()
+deleteGitHubRepoLink (GitHubRepoLinkId linkId) =
+  void $
+    pexec
+      [sql| DELETE FROM github_repo_links WHERE id = ? |]
+      (Only linkId)
+
+-- | Parser for GitHubRepoLink rows
+repoLinkParser :: RowParser (GitHubRepoLinkId, GitHubRepoLink)
+repoLinkParser = do
+  linkId <- idParser GitHubRepoLinkId
+  projectId <- idParser ProjectId
+  owner <- field
+  repo <- field
+  secret <- field
+  createdBy <- idParser UserId
+  createdAt <- utcParser
+  pure
+    ( linkId,
+      GitHubRepoLink
+        { _repoLinkProjectId = projectId,
+          _repoLinkOwner = owner,
+          _repoLinkRepo = repo,
+          _repoLinkWebhookSecret = secret,
+          _repoLinkCreatedBy = createdBy,
+          _repoLinkCreatedAt = createdAt
+        }
+    )
+
+-- | Record a webhook event for auditing/idempotency.
+-- This is used by the legacy non-claim path (no concurrent-delivery race
+-- protection). New code should use 'claimWebhookDelivery' followed by
+-- 'finalizeWebhookDelivery'.
+recordWebhookEvent :: GitHubRepoLinkId -> GitHubWebhookEvent -> DBM GitHubWebhookEventId
+recordWebhookEvent (GitHubRepoLinkId linkId) ev =
+  pinsert
+    GitHubWebhookEventId
+    [sql| INSERT INTO github_webhook_events
+          (repo_link_id, github_delivery_id, event_type, pr_number,
+           pr_author_github_login, time_spent_parsed, status, error_message,
+           work_event_id, user_id, user_created, received_at, processed_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?::github_event_status, ?, ?, ?, ?, ?, ?)
+          RETURNING id |]
+    ( linkId,
+      _webhookEventDeliveryId ev,
+      _webhookEventType ev,
+      _webhookEventPRNumber ev,
+      fmap (\(GitHubUsername u) -> u) (_webhookEventAuthorLogin ev),
+      fmap (round . C.toSeconds' :: C.NominalDiffTime -> Int64) (_webhookEventTimeSpent ev),
+      statusToText (_webhookEventStatus ev),
+      _webhookEventErrorMessage ev,
+      fmap (\(EventId eid) -> eid) (_webhookEventWorkEventId ev),
+      fmap (\(UserId uid) -> uid) (_webhookEventUserId ev),
+      _webhookEventUserCreated ev,
+      fromThyme $ _webhookEventReceivedAt ev,
+      fmap fromThyme (_webhookEventProcessedAt ev)
+    )
+
+-- | Atomically claim a webhook delivery for processing. Inserts a row in
+-- the 'processing' state and returns the row id on first claim; returns
+-- 'Nothing' if some other concurrent caller already inserted the row for
+-- the same delivery id. This is the idempotency guard against duplicate
+-- deliveries racing to create work events.
+claimWebhookDelivery ::
+  GitHubRepoLinkId ->
+  -- | delivery id (GitHub's X-GitHub-Delivery)
+  Text ->
+  -- | event type (X-GitHub-Event)
+  Text ->
+  -- | received-at
+  C.UTCTime ->
+  DBM (Maybe GitHubWebhookEventId)
+claimWebhookDelivery (GitHubRepoLinkId linkId) deliveryId eventType receivedAt = do
+  rows <-
+    pquery
+      (idParser GitHubWebhookEventId)
+      [sql| INSERT INTO github_webhook_events
+              (repo_link_id, github_delivery_id, event_type, status, received_at)
+            VALUES (?, ?, ?, 'processing'::github_event_status, ?)
+            ON CONFLICT (github_delivery_id) DO NOTHING
+            RETURNING id |]
+      (linkId, deliveryId, eventType, fromThyme receivedAt)
+  pure $ headMay rows
+
+-- | Update a previously claimed webhook delivery row to its final state.
+finalizeWebhookDelivery :: GitHubWebhookEventId -> GitHubWebhookEvent -> DBM ()
+finalizeWebhookDelivery (GitHubWebhookEventId rowId) ev =
+  void $
+    pexec
+      [sql| UPDATE github_webhook_events
+            SET pr_number = ?,
+                pr_author_github_login = ?,
+                time_spent_parsed = ?,
+                status = ?::github_event_status,
+                error_message = ?,
+                work_event_id = ?,
+                user_id = ?,
+                user_created = ?,
+                processed_at = ?
+            WHERE id = ? |]
+      ( _webhookEventPRNumber ev,
+        fmap (\(GitHubUsername u) -> u) (_webhookEventAuthorLogin ev),
+        fmap (round . C.toSeconds' :: C.NominalDiffTime -> Int64) (_webhookEventTimeSpent ev),
+        statusToText (_webhookEventStatus ev),
+        _webhookEventErrorMessage ev,
+        fmap (\(EventId eid) -> eid) (_webhookEventWorkEventId ev),
+        fmap (\(UserId uid) -> uid) (_webhookEventUserId ev),
+        _webhookEventUserCreated ev,
+        fmap fromThyme (_webhookEventProcessedAt ev),
+        rowId
+      )
+
+-- | Check if a delivery has already been processed
+isDeliveryProcessed :: Text -> DBM Bool
+isDeliveryProcessed deliveryId = do
+  results <-
+    pquery
+      (field :: RowParser Bool)
+      [sql| SELECT EXISTS(
+              SELECT 1 FROM github_webhook_events
+              WHERE github_delivery_id = ?
+            ) |]
+      (Only deliveryId)
+  pure $ fromMaybe False (headMay results)
+
+-- | Convert event status to database text representation
+statusToText :: GitHubEventStatus -> Text
+statusToText = \case
+  EventProcessing -> "processing"
+  EventProcessed -> "processed"
+  EventSkipped -> "skipped"
+  EventError -> "error"

--- a/core/lib/Aftok/Database/PostgreSQL/Users.hs
+++ b/core/lib/Aftok/Database/PostgreSQL/Users.hs
@@ -4,7 +4,8 @@
 {-# LANGUAGE QuasiQuotes #-}
 
 module Aftok.Database.PostgreSQL.Users
-  ( createUserWithPassword,
+  ( createUser,
+    createUserWithPassword,
     findUser,
     findUserByName,
     findUserByNameWithPassword,
@@ -15,12 +16,17 @@ module Aftok.Database.PostgreSQL.Users
     updateUserPassword,
     setUserZcashAddress,
     findUserZcashAddress,
+    -- GitHub username operations
+    findUserByGitHubUsername,
+    linkGitHubUsername,
+    unlinkGitHubUsername,
+    getUserGitHubUsername,
   )
 where
 
 import Aftok.Currency (Currency (..))
 import qualified Aftok.Currency.Zcash as Zcash
-import Aftok.Database ()
+import Aftok.Database (DBError (..))
 import Aftok.Database.PostgreSQL.Types
   ( DBM,
     askNetworkMode,
@@ -33,9 +39,12 @@ import Aftok.Database.PostgreSQL.Types
     zcashAddressParser,
     zcashIvkParser,
   )
+import Aftok.GitHub (normalizeGitHubUsername)
 import Aftok.Password (PasswordHash (..))
 import Aftok.Types
+import qualified Control.Exception as Ex
 import Control.Lens
+import Control.Monad.Trans.Except (throwE)
 import qualified Data.Thyme.Clock as C
 import Database.PostgreSQL.Simple
 import Database.PostgreSQL.Simple.FromRow
@@ -51,6 +60,22 @@ userParser = do
   remail <- fmap (RecoverByEmail . Email) <$> field
   rzaddr <- fmap (RecoverByZAddr . Zcash.Address) <$> field
   User uname <$> maybe empty pure (remail <|> rzaddr)
+
+createUser :: User -> DBM UserId
+createUser user' = do
+  uid <-
+    pinsert
+      UserId
+      [sql| INSERT INTO users (handle, recovery_email, recovery_zaddr)
+          VALUES (?, ?, ?) RETURNING id |]
+      ( user' ^. (username . _UserName),
+        user' ^? userAccountRecovery . _RecoverByEmail . _Email,
+        user' ^? userAccountRecovery . _RecoverByZAddr . Zcash._Address
+      )
+  case user' ^. userAccountRecovery of
+    RecoverByZAddr addr -> linkZcashAccount uid addr
+    RecoverByEmail _ -> pure ()
+  pure uid
 
 createUserWithPassword :: User -> PasswordHash -> DBM UserId
 createUserWithPassword user' pwdHash = do
@@ -226,3 +251,56 @@ setUserZcashAddress uid addr = do
     Nothing ->
       -- Insert a new primary account row
       linkZcashAccount uid addr
+
+-- | Find a user by their linked GitHub username (case-insensitive).
+findUserByGitHubUsername :: GitHubUsername -> DBM (Maybe (UserId, User))
+findUserByGitHubUsername (GitHubUsername ghUser) = do
+  let normalized = normalizeGitHubUsername ghUser
+  headMay
+    <$> pquery
+      ((,) <$> idParser UserId <*> userParser)
+      [sql| SELECT id, handle, recovery_email, recovery_zaddr
+            FROM users
+            WHERE github_username = ? |]
+      (Only normalized)
+
+-- | Link a GitHub username to a user account. Stores the canonical
+-- lowercased form so that subsequent lookups match GitHub's
+-- case-insensitive login semantics. Raises 'DuplicateRecord' on the
+-- 'users.github_username' unique-constraint violation.
+linkGitHubUsername :: UserId -> GitHubUsername -> DBM ()
+linkGitHubUsername (UserId uid) (GitHubUsername ghUser) = do
+  let normalized = normalizeGitHubUsername ghUser
+  conn <- asks snd
+  result <-
+    liftIO $
+      Ex.try $
+        execute
+          conn
+          [sql| UPDATE users SET github_username = ? WHERE id = ? |]
+          (normalized, uid)
+  case result of
+    Right _ -> pure ()
+    Left (e :: SqlError) ->
+      -- Postgres unique_violation: SQLSTATE 23505
+      if sqlState e == "23505"
+        then lift $ throwE $ DuplicateRecord "github_username already linked to another account"
+        else liftIO (Ex.throwIO e)
+
+-- | Unlink a GitHub username from a user account
+unlinkGitHubUsername :: UserId -> DBM ()
+unlinkGitHubUsername (UserId uid) =
+  void $
+    pexec
+      [sql| UPDATE users SET github_username = NULL WHERE id = ? |]
+      (Only uid)
+
+-- | Get the GitHub username linked to a user account
+getUserGitHubUsername :: UserId -> DBM (Maybe GitHubUsername)
+getUserGitHubUsername (UserId uid) = do
+  results <-
+    pquery
+      (fmap GitHubUsername <$> field)
+      [sql| SELECT github_username FROM users WHERE id = ? |]
+      (Only uid)
+  pure $ join (headMay results)

--- a/core/lib/Aftok/GitHub.hs
+++ b/core/lib/Aftok/GitHub.hs
@@ -1,0 +1,270 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Aftok.GitHub
+  ( -- * Types
+    GitHubRepoLink (..),
+    repoLinkProjectId,
+    repoLinkOwner,
+    repoLinkRepo,
+    repoLinkWebhookSecret,
+    repoLinkCreatedBy,
+    repoLinkCreatedAt,
+    GitHubEventStatus (..),
+    GitHubWebhookEvent (..),
+    webhookEventDeliveryId,
+    webhookEventType,
+    webhookEventPRNumber,
+    webhookEventAuthorLogin,
+    webhookEventTimeSpent,
+    webhookEventStatus,
+    webhookEventErrorMessage,
+    webhookEventWorkEventId,
+    webhookEventUserId,
+    webhookEventUserCreated,
+    webhookEventReceivedAt,
+    webhookEventProcessedAt,
+
+    -- * Duration parsing
+    Duration (..),
+    durationHours,
+    durationMinutes,
+    parseDuration,
+    parseTimeSpent,
+    durationToNDT,
+
+    -- * Username normalization
+    normalizeGitHubUsername,
+
+    -- * Skip reasons
+    SkipReason (..),
+    skipReasonText,
+
+    -- * Webhook signature verification
+    verifySignature,
+  )
+where
+
+import Aftok.TimeLog (EventId)
+import Aftok.Types
+  ( GitHubUsername (..),
+    ProjectId,
+    UserId,
+  )
+import Control.Lens (makeLenses)
+import qualified Crypto.Hash as Hash
+import Crypto.MAC.HMAC (HMAC (..), hmac)
+import Data.Attoparsec.Text as A
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as B16
+import qualified Data.Char as Char
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import qualified Data.Thyme.Clock as C
+
+-- | A link between a GitHub repository and an Aftok project
+data GitHubRepoLink = GitHubRepoLink
+  { _repoLinkProjectId :: !ProjectId,
+    _repoLinkOwner :: !Text,
+    _repoLinkRepo :: !Text,
+    _repoLinkWebhookSecret :: !Text,
+    _repoLinkCreatedBy :: !UserId,
+    _repoLinkCreatedAt :: !C.UTCTime
+  }
+  deriving (Show, Eq)
+
+makeLenses ''GitHubRepoLink
+
+-- | Status of a processed webhook event.
+data GitHubEventStatus
+  = -- | The delivery is currently being processed (transient claim row,
+    -- updated to a terminal status when the handler finishes).
+    EventProcessing
+  | EventProcessed
+  | EventSkipped
+  | EventError
+  deriving (Show, Eq)
+
+-- | A record of a GitHub webhook event for auditing/idempotency
+data GitHubWebhookEvent = GitHubWebhookEvent
+  { _webhookEventDeliveryId :: !Text,
+    _webhookEventType :: !Text,
+    _webhookEventPRNumber :: !(Maybe Int),
+    _webhookEventAuthorLogin :: !(Maybe GitHubUsername),
+    _webhookEventTimeSpent :: !(Maybe C.NominalDiffTime),
+    _webhookEventStatus :: !GitHubEventStatus,
+    _webhookEventErrorMessage :: !(Maybe Text),
+    _webhookEventWorkEventId :: !(Maybe EventId),
+    _webhookEventUserId :: !(Maybe UserId),
+    _webhookEventUserCreated :: !Bool,
+    _webhookEventReceivedAt :: !C.UTCTime,
+    _webhookEventProcessedAt :: !(Maybe C.UTCTime)
+  }
+  deriving (Show, Eq)
+
+makeLenses ''GitHubWebhookEvent
+
+-- | A duration in hours and minutes
+data Duration = Duration
+  { _durationHours :: !Int,
+    _durationMinutes :: !Int
+  }
+  deriving (Show, Eq)
+
+makeLenses ''Duration
+
+-- | Convert a Duration to NominalDiffTime
+durationToNDT :: Duration -> C.NominalDiffTime
+durationToNDT (Duration h m) = C.fromSeconds' $ toRational $ (h * 3600) + (m * 60)
+
+-- | Parse a duration string in various formats:
+-- - "2h30m", "2h 30m", "2h", "30m"
+-- - "2 hours 30 minutes", "2 hours", "30 minutes"
+-- - "2.5h", "2.5 hours"
+-- - "150m", "150 minutes"
+parseDuration :: Text -> Maybe Duration
+parseDuration input =
+  case parseOnly durationParser (T.strip $ T.toLower input) of
+    Right d -> Just d
+    Left _ -> Nothing
+
+-- | Parser for duration values
+durationParser :: Parser Duration
+durationParser =
+  hoursMinutesParser
+    <|> decimalHoursParser
+    <|> totalMinutesParser
+
+-- | Parse "2h30m", "2h 30m", "2 hours 30 minutes", etc. Also tolerates a
+-- single component being absent (just hours, just minutes). Any minutes
+-- value >= 60 is carried into hours so the resulting 'Duration' is
+-- normalized.
+hoursMinutesParser :: Parser Duration
+hoursMinutesParser = do
+  h <- option 0 hoursComponent
+  skipSpace
+  m <- option 0 minutesComponent
+  endOfInput
+  let totalMinutes = (h * 60) + m
+      h' = totalMinutes `div` 60
+      m' = totalMinutes `mod` 60
+  if totalMinutes == 0
+    then fail "Duration must be non-zero"
+    else pure $ Duration h' m'
+
+-- | Parse hours component: "2h", "2 hours", "2 hour". Longest-match-first
+-- alternation is required because attoparsec's 'string' commits on
+-- partial matches; matching "h" first would leave "ours" unconsumed.
+hoursComponent :: Parser Int
+hoursComponent = do
+  n <- decimal
+  skipSpace
+  _ <- string "hours" <|> string "hour" <|> string "h"
+  pure n
+
+-- | Parse minutes component: "30m", "30 minutes", "30 minute"
+minutesComponent :: Parser Int
+minutesComponent = do
+  n <- decimal
+  skipSpace
+  _ <- string "minutes" <|> string "minute" <|> string "m"
+  pure n
+
+-- | Parse decimal hours: "2.5h", "2.5 hours"
+decimalHoursParser :: Parser Duration
+decimalHoursParser = do
+  n <- double
+  skipSpace
+  _ <- string "hours" <|> string "hour" <|> string "h"
+  endOfInput
+  let totalMinutes = round (n * 60)
+      h = totalMinutes `div` 60
+      m = totalMinutes `mod` 60
+  pure $ Duration h m
+
+-- | Parse total minutes: "150m", "150 minutes"
+totalMinutesParser :: Parser Duration
+totalMinutesParser = do
+  n <- decimal
+  skipSpace
+  _ <- string "minutes" <|> string "minute" <|> string "m"
+  endOfInput
+  let h = n `div` 60
+      m = n `mod` 60
+  pure $ Duration h m
+
+-- | Extract "Time Spent: <duration>" from a PR body (case-insensitive)
+-- Returns the parsed duration if found
+parseTimeSpent :: Text -> Maybe Duration
+parseTimeSpent body =
+  let patterns = ["time spent:", "time-spent:", "timespent:"]
+   in case mapMaybe tryPattern patterns of
+        (d : _) -> Just d
+        [] -> Nothing
+  where
+    tryPattern pat =
+      let (_, after) = T.breakOn pat (T.toLower body)
+       in if T.null after
+            then Nothing
+            else
+              let -- Extract the duration text after the pattern
+                  afterPattern = T.drop (T.length pat) after
+                  -- Take characters until end of line or next whitespace block
+                  durationText = T.strip $ T.takeWhile (not . isEndOfDuration) $ T.dropWhile Char.isSpace afterPattern
+               in parseDuration durationText
+
+    isEndOfDuration c = c == '\n' || c == '\r'
+
+-- | Normalize a GitHub username to its canonical form. GitHub treats
+-- usernames case-insensitively, so we lowercase at every store and lookup
+-- site.
+normalizeGitHubUsername :: Text -> Text
+normalizeGitHubUsername = T.toLower
+
+-- | Structured reasons a webhook delivery is recorded but not turned into
+-- work events. Stored in the audit log via 'skipReasonText'.
+data SkipReason
+  = -- | The webhook payload did not parse to the expected PR-event shape.
+    SRInvalidPayload
+  | -- | A pull_request event whose action/merged state is uninteresting
+    -- (only closed-and-merged PRs are processed).
+    SRPRNotMerged !Text !Bool
+  | -- | The PR body did not contain a parseable "Time Spent:" marker.
+    SRNoTimeSpent
+  | -- | The PR merger and author are both unknown to Aftok, so no user
+    -- can be credited.
+    SRUnknownAuthor
+  deriving (Show, Eq)
+
+-- | Render a 'SkipReason' as audit-log text.
+skipReasonText :: SkipReason -> Text
+skipReasonText = \case
+  SRInvalidPayload -> "Could not parse PR info from payload"
+  SRPRNotMerged action merged ->
+    "PR action=" <> action <> ", merged=" <> (if merged then "True" else "False")
+  SRNoTimeSpent -> "No 'Time Spent:' found in PR body"
+  SRUnknownAuthor -> "Merger not project member and author not found"
+
+-- | Verify a GitHub-style HMAC-SHA256 signature header (the
+-- @X-Hub-Signature-256@ value, of the form @sha256=<hex>@) against the
+-- raw request body bytes. The body MUST be the exact bytes GitHub sent;
+-- re-encoding parsed JSON yields a different byte sequence and fails
+-- this check.
+--
+-- The comparison is performed in constant time on the raw digest bytes
+-- (after stripping the @sha256=@ prefix and hex-decoding the provided
+-- signature), not on hex-encoded strings.
+verifySignature :: Text -> Text -> ByteString -> Bool
+verifySignature secret signature payload =
+  let secretBytes = T.encodeUtf8 secret
+      digest = hmac secretBytes payload :: HMAC Hash.SHA256
+      expectedBytes = BA.convert (hmacGetDigest digest) :: ByteString
+      sigBs = T.encodeUtf8 signature
+   in case BS.stripPrefix "sha256=" sigBs of
+        Nothing -> False
+        Just hexPart ->
+          case B16.decode hexPart of
+            Right providedBytes
+              | BS.length providedBytes == BS.length expectedBytes ->
+                  BA.constEq providedBytes expectedBytes
+            _ -> False

--- a/core/lib/Aftok/Types.hs
+++ b/core/lib/Aftok/Types.hs
@@ -22,6 +22,10 @@ newtype Email = Email Text deriving (Show, Eq)
 
 makePrisms ''Email
 
+newtype GitHubUsername = GitHubUsername Text deriving (Show, Eq)
+
+makePrisms ''GitHubUsername
+
 data RecoverBy z
   = RecoverByEmail Email
   | RecoverByZAddr z
@@ -85,3 +89,12 @@ data DepreciationRules = DepreciationRules
   }
 
 makeLenses ''DepreciationRules
+
+-- GitHub integration types
+newtype GitHubRepoLinkId = GitHubRepoLinkId UUID deriving (Show, Eq, Ord)
+
+makePrisms ''GitHubRepoLinkId
+
+newtype GitHubWebhookEventId = GitHubWebhookEventId UUID deriving (Show, Eq, Ord)
+
+makePrisms ''GitHubWebhookEventId

--- a/core/test/Aftok/GitHubSpec.hs
+++ b/core/test/Aftok/GitHubSpec.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Aftok.GitHubSpec where
+
+import Aftok.GitHub
+  ( Duration (..),
+    parseDuration,
+    parseTimeSpent,
+    verifySignature,
+  )
+import qualified Data.Aeson as A
+import qualified Data.ByteString.Lazy as LBS
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "parseDuration" $ do
+    it "parses '2h30m'" $
+      parseDuration "2h30m" `shouldBe` Just (Duration 2 30)
+    it "parses '2h 30m' with internal whitespace" $
+      parseDuration "2h 30m" `shouldBe` Just (Duration 2 30)
+    it "parses decimal hours '2.5h'" $
+      parseDuration "2.5h" `shouldBe` Just (Duration 2 30)
+    it "parses total minutes '150m' as 2h30m" $
+      parseDuration "150m" `shouldBe` Just (Duration 2 30)
+    it "parses '2 hours' long form" $
+      parseDuration "2 hours" `shouldBe` Just (Duration 2 0)
+    it "parses '30 minutes' long form" $
+      parseDuration "30 minutes" `shouldBe` Just (Duration 0 30)
+    it "trims leading and trailing whitespace" $
+      parseDuration "   2h30m   " `shouldBe` Just (Duration 2 30)
+    it "is case-insensitive" $
+      parseDuration "2H30M" `shouldBe` Just (Duration 2 30)
+    it "rejects invalid input" $
+      parseDuration "not a duration" `shouldBe` Nothing
+    it "rejects empty input" $
+      parseDuration "" `shouldBe` Nothing
+    it "rejects zero duration" $
+      parseDuration "0h0m" `shouldBe` Nothing
+
+  describe "parseTimeSpent" $ do
+    it "detects 'Time Spent:' (case-insensitive)" $
+      parseTimeSpent "PR description\n\nTime Spent: 2h30m\n\nthanks"
+        `shouldBe` Just (Duration 2 30)
+    it "detects 'time-spent:'" $
+      parseTimeSpent "time-spent: 2h" `shouldBe` Just (Duration 2 0)
+    it "detects 'timespent:' compact form" $
+      parseTimeSpent "timespent: 45m" `shouldBe` Just (Duration 0 45)
+    it "matches case-insensitively" $
+      parseTimeSpent "TIME SPENT: 1h" `shouldBe` Just (Duration 1 0)
+    it "honors only the first 'Time Spent:' in a multi-line body" $
+      parseTimeSpent
+        "Initial draft.\n\nTime Spent: 2h30m\n\nLater addendum: Time Spent: 99h"
+        `shouldBe` Just (Duration 2 30)
+    it "returns Nothing when no marker is present" $
+      parseTimeSpent "A perfectly normal PR body with no time tracking marker."
+        `shouldBe` Nothing
+    it "returns Nothing when the duration after the marker is unparseable" $
+      parseTimeSpent "Time Spent: forever"
+        `shouldBe` Nothing
+
+  describe "verifySignature" $ do
+    -- Fixture: HMAC-SHA256 of the exact ASCII bytes
+    --   {"hello":"world"}
+    -- under the secret "topsecret". Hex computed once via:
+    --   python3 -c "import hmac, hashlib; \
+    --     print(hmac.new(b'topsecret', b'{\"hello\":\"world\"}', \
+    --                    hashlib.sha256).hexdigest())"
+    let fixturePayload = "{\"hello\":\"world\"}" :: ByteString
+        fixtureSecret = "topsecret"
+        fixtureHex = "afd00617ceb8f63e65ea5c310f06bf78c3901e7a713db532e25da26ad63c7236"
+        fixtureSig = "sha256=" <> fixtureHex
+
+    it "accepts a valid GitHub-style sha256= signature" $
+      verifySignature fixtureSecret fixtureSig fixturePayload
+        `shouldBe` True
+
+    it "rejects a signature whose hex is wrong" $
+      let wrong = "sha256=" <> toText (replicate 64 '0')
+       in verifySignature fixtureSecret wrong fixturePayload
+            `shouldBe` False
+
+    it "rejects a signature with the wrong prefix scheme" $
+      verifySignature fixtureSecret ("sha1=" <> fixtureHex) fixturePayload
+        `shouldBe` False
+
+    it "rejects a malformed (non-hex) signature" $
+      verifySignature fixtureSecret "sha256=nothex" fixturePayload
+        `shouldBe` False
+
+    -- Critical regression test for the "HMAC over raw body" fix.
+    --
+    -- The original handler computed the HMAC over re-encoded JSON
+    -- (toStrict $ A.encode payload), which produces different bytes from
+    -- whatever GitHub originally signed (different whitespace, key order,
+    -- nested-array spacing, etc.). This test demonstrates the divergence:
+    -- parsing the fixture as JSON and re-encoding it yields a byte
+    -- sequence whose HMAC does NOT match the fixture signature, even
+    -- though the JSON is logically identical.
+    it "would reject a re-encoded payload (proves we must HMAC raw bytes)" $ do
+      let rawPayload =
+            "{\"b\": 2, \"a\": 1, \"nested\": {\"x\": [1,2,3]}}" :: ByteString
+          -- Hex computed once over the raw bytes above with secret "topsecret":
+          rawHex = "3e0fd72b4f31df65cca479603bf5bcb663bb620a387b55afbbc02c0a8007b9fe"
+          rawSig = "sha256=" <> rawHex
+      -- The raw bytes verify correctly.
+      verifySignature fixtureSecret rawSig rawPayload `shouldBe` True
+      -- Round-tripping through Aeson changes the byte sequence...
+      let parsed = A.eitherDecodeStrict rawPayload :: Either String A.Value
+      case parsed of
+        Left e -> expectationFailure $ "fixture must be valid JSON: " <> e
+        Right v -> do
+          let reencoded = LBS.toStrict (A.encode v)
+          reencoded `shouldNotBe` rawPayload
+          -- ...so signing the re-encoded form would fail against the
+          -- original signature. This is exactly the bug the raw-bytes fix
+          -- prevents.
+          verifySignature fixtureSecret rawSig reencoded `shouldBe` False
+
+main :: IO ()
+main = hspec spec

--- a/executables/aftok-executables.cabal
+++ b/executables/aftok-executables.cabal
@@ -97,14 +97,17 @@ Executable aftok-server
     Aftok.Servant.WorkLog
     Aftok.Servant.Auctions
     Aftok.Servant.Billing
+    Aftok.Servant.GitHub
     Aftok.Servant.Payments
 
   build-depends:
     aftok,
     aftok-api,
+    base16-bytestring         >= 1.0 && < 1.1,
     dbmigrations              >= 3.0 && < 3.1,
     dbmigrations-postgresql-simple >= 0.1 && < 0.2,
     directory                 >= 1.3.6,
+    memory                    >= 0.18 && < 0.19,
     http-client-tls           >= 0.3.6,
     jose                      >= 0.10 && < 0.12,
     resource-pool             >= 0.4 && < 0.5,

--- a/executables/server/Aftok/Servant/App.hs
+++ b/executables/server/Aftok/Servant/App.hs
@@ -10,6 +10,7 @@ module Aftok.Servant.App
     envConfig,
     envCookieSettings,
     envJWTSettings,
+    envHttpManager,
     appToHandler,
     runDB,
     dbErrorToServerError,
@@ -25,6 +26,7 @@ import Control.Monad.Except (MonadError, throwError)
 import Data.Aeson (encode)
 import Data.Pool (Pool, withResource)
 import Database.PostgreSQL.Simple (Connection)
+import qualified Network.HTTP.Client as HTTP
 import Servant (Handler, ServerError, err403, err404, err409, err500, errBody)
 import Servant.Auth.Server (CookieSettings, JWTSettings)
 
@@ -34,7 +36,8 @@ data AppEnv = AppEnv
     _envDbPool :: !(Pool Connection),
     _envConfig :: !ServerConfig,
     _envCookieSettings :: !CookieSettings,
-    _envJWTSettings :: !JWTSettings
+    _envJWTSettings :: !JWTSettings,
+    _envHttpManager :: !HTTP.Manager
   }
 
 makeLenses ''AppEnv

--- a/executables/server/Aftok/Servant/GitHub.hs
+++ b/executables/server/Aftok/Servant/GitHub.hs
@@ -1,0 +1,714 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Aftok.Servant.GitHub
+  ( -- * Handlers
+    gitHubWebhookServer,
+    gitHubProjectServer,
+    gitHubUserServer,
+    gitHubOAuthCallbackHandler,
+  )
+where
+
+import Aftok.API.GitHub
+  ( GitHubOAuthInitResponse (..),
+    GitHubProjectAPI,
+    GitHubUserAPI,
+    GitHubUsernameResponse (..),
+    GitHubWebhookAPI,
+    GitHubWebhookPayload (..),
+    LinkRepoRequest (..),
+    LinkRepoResponse (..),
+    RepoLinkInfo (..),
+  )
+import Aftok.Database
+  ( addUserToProject,
+    claimWebhookDelivery,
+    createEvent,
+    createGitHubRepoLink,
+    createUser,
+    deleteGitHubRepoLink,
+    finalizeWebhookDelivery,
+    findGitHubRepoLink,
+    findProjectGitHubRepoLinks,
+    findUserByGitHubUsername,
+    findUserProjects,
+    getUserGitHubUsername,
+    linkGitHubUsername,
+    unlinkGitHubUsername,
+  )
+import Aftok.GitHub
+  ( GitHubEventStatus (..),
+    GitHubRepoLink (..),
+    GitHubWebhookEvent (..),
+    SkipReason (..),
+    durationToNDT,
+    normalizeGitHubUsername,
+    parseTimeSpent,
+    skipReasonText,
+    verifySignature,
+  )
+import Aftok.Servant.App (AppM, envConfig, envHttpManager, envJWTSettings, runDB)
+import Aftok.Servant.Auth (AuthenticatedUser (..))
+import Aftok.ServerConfig (GitHubOAuthConfig, externalPort, ghOAuthClientId, ghOAuthClientSecret, gitHubOAuthConfig, hostname, secureCookies)
+import Aftok.TimeLog
+  ( CreditTo (..),
+    EventId,
+    LogEntry (..),
+    LogEvent (..),
+  )
+import Aftok.Types
+  ( Email (..),
+    GitHubRepoLinkId (..),
+    GitHubUsername (..),
+    GitHubWebhookEventId,
+    ProjectId,
+    RecoverBy (..),
+    User (..),
+    UserId,
+    UserName (..),
+  )
+import Control.Lens ((^.))
+import Control.Monad.Except (catchError)
+import Crypto.Random (getRandomBytes)
+import Data.Aeson
+  ( Value (..),
+    (.=),
+  )
+import qualified Data.Aeson as A
+import qualified Data.Aeson.KeyMap as KM
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as B16
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import qualified Data.Thyme.Clock as C
+import Data.Thyme.Time.Core (toThyme)
+import qualified Data.Time as Time
+import Data.UUID (UUID)
+import qualified Network.HTTP.Client as HTTP
+import Network.HTTP.Types.Status (statusCode)
+import qualified Network.HTTP.Types.URI as URI
+import Servant
+import Servant.Auth.Server (AuthResult (..), makeJWT, verifyJWT)
+
+--------------------------------------------------------------------------------
+-- Webhook handler
+--------------------------------------------------------------------------------
+
+-- | Webhook server (public, signature-verified).
+--
+-- The request body is taken as raw bytes. HMAC verification must compare
+-- against exactly what GitHub signed; re-encoding parsed JSON yields a
+-- different byte sequence (key order, spacing) and would reject every
+-- legitimate delivery. The body is parsed to JSON only after signature
+-- verification succeeds.
+gitHubWebhookServer ::
+  ServerT GitHubWebhookAPI AppM
+gitHubWebhookServer mContentType mEventType mDeliveryId mSignature (GitHubWebhookPayload payloadBytes) = do
+  -- Validate required headers
+  eventType <- requireHeader mEventType "Missing X-GitHub-Event header"
+  deliveryId <- requireHeader mDeliveryId "Missing X-GitHub-Delivery header"
+  signature <- requireHeader mSignature "Missing X-Hub-Signature-256 header"
+
+  -- Enforce JSON content-type. GitHub allows webhook config to specify
+  -- application/x-www-form-urlencoded, which would interfere with both
+  -- HMAC verification and our JSON parsing; reject anything else.
+  case mContentType of
+    Nothing -> throwError err400 {errBody = "Missing Content-Type header"}
+    Just ct
+      | T.toLower (T.takeWhile (/= ';') (T.strip ct)) == "application/json" -> pure ()
+      | otherwise ->
+          throwError
+            err400
+              { errBody = "Unsupported Content-Type; webhook must be application/json"
+              }
+
+  if eventType /= "pull_request"
+    then pure NoContent
+    else processWebhook eventType deliveryId signature payloadBytes
+  where
+    requireHeader Nothing msg = throwError err400 {errBody = msg}
+    requireHeader (Just v) _ = pure v
+
+-- | Internal webhook processing (after header validation).
+processWebhook :: Text -> Text -> Text -> ByteString -> AppM NoContent
+processWebhook eventType deliveryId signature payloadBytes = do
+  -- Parse the body. Use the same bytes that we'll HMAC-verify against.
+  payload <- case A.eitherDecodeStrict payloadBytes of
+    Right v -> pure v
+    Left _ -> throwError err400 {errBody = "Malformed JSON body"}
+
+  -- Extract repository info from payload (needed to find the secret).
+  let mRepoInfo = do
+        obj <- case payload of
+          Object o -> Just o
+          _ -> Nothing
+        repo <-
+          KM.lookup "repository" obj >>= \case
+            Object r -> Just r
+            _ -> Nothing
+        ownerObj <-
+          KM.lookup "owner" repo >>= \case
+            Object o -> Just o
+            _ -> Nothing
+        ownerLogin <-
+          KM.lookup "login" ownerObj >>= \case
+            String s -> Just s
+            _ -> Nothing
+        repoName <-
+          KM.lookup "name" repo >>= \case
+            String s -> Just s
+            _ -> Nothing
+        pure (ownerLogin, repoName)
+
+  (owner, repo) <- maybe (throwError err400 {errBody = "Invalid payload structure"}) pure mRepoInfo
+
+  -- Find the repo link to verify signature
+  mRepoLink <- runDB $ runMaybeT $ findGitHubRepoLink owner repo
+  (repoLinkId, repoLink) <- maybe (throwError err404 {errBody = "Repository not linked to any project"}) pure mRepoLink
+
+  -- Verify HMAC signature against raw bytes using constant-time compare.
+  let secret = _repoLinkWebhookSecret repoLink
+  unless (verifySignature secret signature payloadBytes) $
+    throwError err401 {errBody = "Invalid signature"}
+
+  -- Atomically claim the delivery id. If another concurrent delivery has
+  -- already claimed it, skip processing. (The single-row INSERT ... ON
+  -- CONFLICT serves both as idempotency and as a race guard.)
+  now <- liftIO $ toThyme <$> Time.getCurrentTime
+  mClaim <- runDB $ claimWebhookDelivery repoLinkId deliveryId eventType now
+  case mClaim of
+    Nothing -> pure NoContent
+    Just rowId -> processWebhookEvent repoLink rowId deliveryId payload now
+
+-- | Process a verified, claimed webhook event. On exit, the claim row is
+-- updated to a terminal status via 'finalizeWebhookDelivery'.
+processWebhookEvent ::
+  GitHubRepoLink ->
+  GitHubWebhookEventId ->
+  Text ->
+  Value ->
+  C.UTCTime ->
+  AppM NoContent
+processWebhookEvent repoLink rowId deliveryId payload now = do
+  -- Extract PR info from payload
+  let extractPRInfo = do
+        obj <- case payload of
+          Object o -> Just o
+          _ -> Nothing
+        action <-
+          KM.lookup "action" obj >>= \case
+            String s -> Just s
+            _ -> Nothing
+        pr <-
+          KM.lookup "pull_request" obj >>= \case
+            Object p -> Just p
+            _ -> Nothing
+        merged <-
+          KM.lookup "merged" pr >>= \case
+            Bool b -> Just b
+            _ -> Nothing
+        prNumber <-
+          KM.lookup "number" pr >>= \case
+            Number n -> Just (round n :: Int)
+            _ -> Nothing
+        prBody <-
+          KM.lookup "body" pr >>= \case
+            String s -> Just s
+            Null -> Just ""
+            _ -> Nothing
+        mergedAt <-
+          KM.lookup "merged_at" pr >>= \case
+            String s -> parseISO8601 s
+            _ -> Nothing
+        prUrl <-
+          KM.lookup "html_url" pr >>= \case
+            String s -> Just s
+            _ -> Nothing
+        prTitle <-
+          KM.lookup "title" pr >>= \case
+            String s -> Just s
+            _ -> Nothing
+
+        -- Get merged_by info
+        mergedBy <-
+          KM.lookup "merged_by" pr >>= \case
+            Object m -> Just m
+            _ -> Nothing
+        mergerLogin <-
+          KM.lookup "login" mergedBy >>= \case
+            String s -> Just s
+            _ -> Nothing
+
+        -- Get author info from the user object
+        userObj <-
+          KM.lookup "user" pr >>= \case
+            Object u -> Just u
+            _ -> Nothing
+        authorLogin <-
+          KM.lookup "login" userObj >>= \case
+            String s -> Just s
+            _ -> Nothing
+
+        pure (action, merged, prNumber, prBody, mergedAt, prUrl, prTitle, mergerLogin, authorLogin)
+
+  case extractPRInfo of
+    Nothing ->
+      -- Invalid payload, record and skip
+      skipEvent Nothing Nothing Nothing SRInvalidPayload
+    Just (action, merged, prNumber, prBody, mergedAt, prUrl, prTitle, mergerLogin, authorLogin) ->
+      -- Only process closed PRs that were merged
+      if not (action == "closed" && merged)
+        then
+          skipEvent
+            (Just prNumber)
+            (Just (GitHubUsername (normalizeGitHubUsername authorLogin)))
+            Nothing
+            (SRPRNotMerged action merged)
+        else case parseTimeSpent prBody of
+          Nothing ->
+            skipEvent
+              (Just prNumber)
+              (Just (GitHubUsername (normalizeGitHubUsername authorLogin)))
+              Nothing
+              SRNoTimeSpent
+          Just duration -> do
+            let projectId = _repoLinkProjectId repoLink
+                timeSpent = durationToNDT duration
+                ghAuthor = GitHubUsername (normalizeGitHubUsername authorLogin)
+                ghMerger = GitHubUsername (normalizeGitHubUsername mergerLogin)
+
+            mMerger <- runDB $ runMaybeT $ findUserByGitHubUsername ghMerger
+            mAuthor <- runDB $ runMaybeT $ findUserByGitHubUsername ghAuthor
+
+            case mMerger of
+              Nothing ->
+                case mAuthor of
+                  Just (authorUid, _) ->
+                    creditWork
+                      projectId
+                      authorUid
+                      ghAuthor
+                      timeSpent
+                      mergedAt
+                      prUrl
+                      prTitle
+                      prNumber
+                      False
+                  Nothing ->
+                    skipEvent
+                      (Just prNumber)
+                      (Just ghAuthor)
+                      (Just timeSpent)
+                      SRUnknownAuthor
+              Just (mergerUid, _) ->
+                case mAuthor of
+                  Just (authorUid, _) ->
+                    creditWork
+                      projectId
+                      authorUid
+                      ghAuthor
+                      timeSpent
+                      mergedAt
+                      prUrl
+                      prTitle
+                      prNumber
+                      False
+                  Nothing -> do
+                    -- TODO(review): auto-creating a provisional user the
+                    -- first time a merger credits an unknown GitHub author
+                    -- silently expands the project membership without
+                    -- any reconciliation flow. This is intentional for
+                    -- the prototype but should grow an explicit
+                    -- invitation/claim path before production use.
+                    let provisionalUser =
+                          User
+                            { _username = UserName $ "github_" <> authorLogin,
+                              _userAccountRecovery =
+                                RecoverByEmail
+                                  (Email $ authorLogin <> "@github.placeholder")
+                            }
+                    authorUid <- runDB $ createUser provisionalUser
+                    runDB $ linkGitHubUsername authorUid ghAuthor
+                    runDB $ addUserToProject projectId mergerUid authorUid
+                    creditWork
+                      projectId
+                      authorUid
+                      ghAuthor
+                      timeSpent
+                      mergedAt
+                      prUrl
+                      prTitle
+                      prNumber
+                      True
+  where
+    finalize ev = do
+      runDB $ finalizeWebhookDelivery rowId ev
+      pure NoContent
+
+    skipEvent ::
+      Maybe Int ->
+      Maybe GitHubUsername ->
+      Maybe C.NominalDiffTime ->
+      SkipReason ->
+      AppM NoContent
+    skipEvent mPRNum mAuthor mTimeSpent reason = do
+      let ev =
+            GitHubWebhookEvent
+              { _webhookEventDeliveryId = deliveryId,
+                _webhookEventType = "pull_request",
+                _webhookEventPRNumber = mPRNum,
+                _webhookEventAuthorLogin = mAuthor,
+                _webhookEventTimeSpent = mTimeSpent,
+                _webhookEventStatus = EventSkipped,
+                _webhookEventErrorMessage = Just (skipReasonText reason),
+                _webhookEventWorkEventId = Nothing,
+                _webhookEventUserId = Nothing,
+                _webhookEventUserCreated = False,
+                _webhookEventReceivedAt = now,
+                _webhookEventProcessedAt = Just now
+              }
+      finalize ev
+
+    creditWork projectId authorUid ghAuthor timeSpent mergedAt prUrl prTitle prNumber userCreated = do
+      workEventId <-
+        createWorkEvents
+          projectId
+          authorUid
+          timeSpent
+          mergedAt
+          prUrl
+          prTitle
+          prNumber
+      let ev =
+            GitHubWebhookEvent
+              { _webhookEventDeliveryId = deliveryId,
+                _webhookEventType = "pull_request",
+                _webhookEventPRNumber = Just prNumber,
+                _webhookEventAuthorLogin = Just ghAuthor,
+                _webhookEventTimeSpent = Just timeSpent,
+                _webhookEventStatus = EventProcessed,
+                _webhookEventErrorMessage = Nothing,
+                _webhookEventWorkEventId = Just workEventId,
+                _webhookEventUserId = Just authorUid,
+                _webhookEventUserCreated = userCreated,
+                _webhookEventReceivedAt = now,
+                _webhookEventProcessedAt = Just now
+              }
+      finalize ev
+
+-- | Create StartWork and StopWork events for credited work, returning the
+-- StartWork EventId as the audit reference stored on the webhook row.
+createWorkEvents ::
+  ProjectId ->
+  UserId ->
+  C.NominalDiffTime ->
+  C.UTCTime ->
+  Text ->
+  Text ->
+  Int ->
+  AppM EventId
+createWorkEvents projectId userId duration mergedAt prUrl prTitle prNumber = do
+  let endTime = mergedAt
+      startTime = C.addUTCTime (negate duration) endTime
+      metadata =
+        Just $
+          A.object
+            [ "source" .= ("github_pr" :: Text),
+              "pr_number" .= prNumber,
+              "pr_title" .= prTitle,
+              "pr_url" .= prUrl
+            ]
+      startEntry =
+        LogEntry
+          { _creditTo = CreditToUser userId,
+            _event = StartWork startTime,
+            _eventMeta = metadata
+          }
+      stopEntry =
+        LogEntry
+          { _creditTo = CreditToUser userId,
+            _event = StopWork endTime,
+            _eventMeta = metadata
+          }
+  startId <- runDB $ createEvent projectId userId startEntry
+  _ <- runDB $ createEvent projectId userId stopEntry
+  pure startId
+
+-- | Parse ISO8601 timestamp
+parseISO8601 :: Text -> Maybe C.UTCTime
+parseISO8601 t =
+  toThyme <$> Time.parseTimeM True Time.defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" (T.unpack t)
+
+--------------------------------------------------------------------------------
+-- Project-level GitHub management
+--------------------------------------------------------------------------------
+
+gitHubProjectServer ::
+  AuthResult AuthenticatedUser ->
+  ProjectId ->
+  ServerT GitHubProjectAPI AppM
+gitHubProjectServer authResult pid =
+  listRepoLinksHandler authResult pid
+    :<|> linkRepoHandler authResult pid
+    :<|> unlinkRepoHandler authResult pid
+
+checkMembership :: UserId -> ProjectId -> AppM ()
+checkMembership uid pid = do
+  projects <- runDB $ findUserProjects uid
+  unless (any (\(p, _) -> p == pid) projects) $
+    throwError err403 {errBody = "User is not a member of this project"}
+
+listRepoLinksHandler ::
+  AuthResult AuthenticatedUser ->
+  ProjectId ->
+  AppM [RepoLinkInfo]
+listRepoLinksHandler (Authenticated user) pid = do
+  let uid = auUserId user
+  checkMembership uid pid
+  links <- runDB $ findProjectGitHubRepoLinks pid
+  pure $
+    fmap
+      ( \(rLinkId, link) ->
+          RepoLinkInfo
+            { rliId = rLinkId,
+              rliOwner = _repoLinkOwner link,
+              rliRepo = _repoLinkRepo link,
+              rliCreatedAt = _repoLinkCreatedAt link
+            }
+      )
+      links
+listRepoLinksHandler _ _ =
+  throwError err401 {errBody = "Authentication required"}
+
+-- | Link a repo to a project.
+--
+-- TODO(review): the generated 'webhook_secret' is currently stored in
+-- plaintext in the 'github_repo_links' table. Encryption-at-rest would
+-- require introducing a server master key; leaving as a follow-up.
+linkRepoHandler ::
+  AuthResult AuthenticatedUser ->
+  ProjectId ->
+  LinkRepoRequest ->
+  AppM LinkRepoResponse
+linkRepoHandler (Authenticated user) pid req = do
+  let uid = auUserId user
+  checkMembership uid pid
+  now <- liftIO $ toThyme <$> Time.getCurrentTime
+
+  -- Generate a secure random webhook secret
+  secretBytes <- liftIO $ getRandomBytes 32
+  let secret = T.decodeUtf8 $ B16.encode (secretBytes :: ByteString)
+
+  let link =
+        GitHubRepoLink
+          { _repoLinkProjectId = pid,
+            _repoLinkOwner = lrrOwner req,
+            _repoLinkRepo = lrrRepo req,
+            _repoLinkWebhookSecret = secret,
+            _repoLinkCreatedBy = uid,
+            _repoLinkCreatedAt = now
+          }
+
+  newLinkId <- runDB $ createGitHubRepoLink link
+  pure $
+    LinkRepoResponse
+      { lrLinkId = newLinkId,
+        lrWebhookSecret = secret
+      }
+linkRepoHandler _ _ _ =
+  throwError err401 {errBody = "Authentication required"}
+
+unlinkRepoHandler ::
+  AuthResult AuthenticatedUser ->
+  ProjectId ->
+  UUID ->
+  AppM NoContent
+unlinkRepoHandler (Authenticated user) pid linkUUID = do
+  let uid = auUserId user
+      rLinkId = GitHubRepoLinkId linkUUID
+  checkMembership uid pid
+  runDB $ deleteGitHubRepoLink rLinkId
+  pure NoContent
+unlinkRepoHandler _ _ _ =
+  throwError err401 {errBody = "Authentication required"}
+
+--------------------------------------------------------------------------------
+-- User-level GitHub username linking (OAuth-verified)
+--------------------------------------------------------------------------------
+
+gitHubUserServer ::
+  AuthResult AuthenticatedUser ->
+  ServerT GitHubUserAPI AppM
+gitHubUserServer authResult =
+  getGitHubUsernameHandler authResult
+    :<|> linkGitHubOAuthHandler authResult
+    :<|> unlinkGitHubUsernameHandler authResult
+
+getGitHubUsernameHandler ::
+  AuthResult AuthenticatedUser ->
+  AppM GitHubUsernameResponse
+getGitHubUsernameHandler (Authenticated user) = do
+  let uid = auUserId user
+  mUsername <- runDB $ getUserGitHubUsername uid
+  pure $ GitHubUsernameResponse $ fmap (\(GitHubUsername u) -> u) mUsername
+getGitHubUsernameHandler _ =
+  throwError err401 {errBody = "Authentication required"}
+
+linkGitHubOAuthHandler ::
+  AuthResult AuthenticatedUser ->
+  AppM GitHubOAuthInitResponse
+linkGitHubOAuthHandler (Authenticated user) = do
+  env <- ask
+  let cfg = env ^. envConfig
+      jwtSettings = env ^. envJWTSettings
+  ghCfg <- case cfg ^. gitHubOAuthConfig of
+    Nothing ->
+      throwError err501 {errBody = "GitHub OAuth is not configured"}
+    Just c -> pure c
+  now <- liftIO Time.getCurrentTime
+  let expiry = Time.addUTCTime 600 now -- 10-minute expiry
+  ejwt <- liftIO $ makeJWT user jwtSettings (Just expiry)
+  stateToken <- case ejwt of
+    Left _ -> throwError err500 {errBody = "Failed to generate OAuth state token"}
+    Right jwt -> pure $ decodeUtf8 (LBS.toStrict jwt)
+  let scheme = if cfg ^. secureCookies then "https://" else "http://"
+      host = decodeUtf8 (cfg ^. hostname)
+      portSuffix = maybe "" (\p -> ":" <> show p) (cfg ^. externalPort)
+      redirectUri = scheme <> host <> portSuffix <> "/api/user/github/callback"
+      clientId = ghCfg ^. ghOAuthClientId
+      authUrl =
+        "https://github.com/login/oauth/authorize"
+          <> "?client_id="
+          <> clientId
+          <> "&redirect_uri="
+          <> redirectUri
+          <> "&scope=read:user"
+          <> "&state="
+          <> stateToken
+  pure $ GitHubOAuthInitResponse authUrl
+linkGitHubOAuthHandler _ =
+  throwError err401 {errBody = "Authentication required"}
+
+gitHubOAuthCallbackHandler ::
+  Maybe Text ->
+  Maybe Text ->
+  Maybe Text ->
+  AppM (Headers '[Header "Location" Text] NoContent)
+gitHubOAuthCallbackHandler _mCode _mState (Just ghError) =
+  redirectTo $ "/app/settings?github=error&reason=" <> ghError
+gitHubOAuthCallbackHandler (Just code) (Just stateJwt) _mError = do
+  env <- ask
+  let cfg = env ^. envConfig
+      jwtSettings = env ^. envJWTSettings
+      mgr = env ^. envHttpManager
+  case cfg ^. gitHubOAuthConfig of
+    Nothing ->
+      redirectTo "/app/settings?github=error&reason=not_configured"
+    Just ghCfg -> do
+      mUser <- liftIO $ verifyJWT jwtSettings (encodeUtf8 stateJwt)
+      case (mUser :: Maybe AuthenticatedUser) of
+        Nothing ->
+          redirectTo "/app/settings?github=error&reason=invalid_state"
+        Just user -> do
+          let uid = auUserId user
+          mToken <- liftIO $ exchangeCodeForToken mgr ghCfg code
+          case mToken of
+            Nothing ->
+              redirectTo "/app/settings?github=error&reason=token_exchange_failed"
+            Just token -> do
+              mLogin <- liftIO $ fetchGitHubLogin mgr token
+              case mLogin of
+                Nothing ->
+                  redirectTo "/app/settings?github=error&reason=github_api_failed"
+                Just login ->
+                  linkAndRedirect uid login
+gitHubOAuthCallbackHandler _ _ _ =
+  redirectTo "/app/settings?github=error&reason=missing_params"
+
+-- | Store the OAuth-verified GitHub username. 'linkGitHubUsername' raises
+-- 'DuplicateRecord' (-> 409) on the unique-constraint violation, which we
+-- translate to an 'already_linked' redirect query parameter.
+linkAndRedirect :: UserId -> Text -> AppM (Headers '[Header "Location" Text] NoContent)
+linkAndRedirect uid login =
+  ( runDB (linkGitHubUsername uid (GitHubUsername (normalizeGitHubUsername login)))
+      >> redirectTo "/app/settings?github=linked"
+  )
+    `catchError` \err ->
+      if errHTTPCode err == 409
+        then redirectTo "/app/settings?github=error&reason=already_linked"
+        else redirectTo "/app/settings?github=error&reason=db_error"
+
+redirectTo :: Text -> AppM (Headers '[Header "Location" Text] NoContent)
+redirectTo url = pure $ addHeader url NoContent
+
+-- | Exchange an authorization code for a GitHub access token. The request
+-- body is application/x-www-form-urlencoded; every value is URL-encoded
+-- so that any URL-special characters in the secret or the code don't
+-- corrupt the request.
+exchangeCodeForToken :: HTTP.Manager -> GitHubOAuthConfig -> Text -> IO (Maybe Text)
+exchangeCodeForToken mgr ghCfg code = do
+  let enc = URI.urlEncode True . T.encodeUtf8
+      body =
+        BS.concat
+          [ "client_id=",
+            enc (ghCfg ^. ghOAuthClientId),
+            "&client_secret=",
+            enc (ghCfg ^. ghOAuthClientSecret),
+            "&code=",
+            enc code
+          ]
+  initReq <- HTTP.parseRequest "https://github.com/login/oauth/access_token"
+  let req =
+        initReq
+          { HTTP.method = "POST",
+            HTTP.requestBody = HTTP.RequestBodyBS body,
+            HTTP.requestHeaders =
+              [ ("Accept", "application/json"),
+                ("Content-Type", "application/x-www-form-urlencoded")
+              ]
+          }
+  resp <- HTTP.httpLbs req mgr
+  case A.decode (HTTP.responseBody resp) of
+    Just (Object obj) ->
+      case KM.lookup "access_token" obj of
+        Just (String token) -> pure (Just token)
+        _ -> pure Nothing
+    _ -> pure Nothing
+
+-- | Fetch the authenticated GitHub user's login name.
+fetchGitHubLogin :: HTTP.Manager -> Text -> IO (Maybe Text)
+fetchGitHubLogin mgr token = do
+  initReq <- HTTP.parseRequest "https://api.github.com/user"
+  let req =
+        initReq
+          { HTTP.requestHeaders =
+              [ ("Authorization", "Bearer " <> T.encodeUtf8 token),
+                ("Accept", "application/json"),
+                ("User-Agent", "aftok-server")
+              ]
+          }
+  resp <- HTTP.httpLbs req mgr
+  if statusCode (HTTP.responseStatus resp) /= 200
+    then pure Nothing
+    else case A.decode (HTTP.responseBody resp) of
+      Just (Object obj) ->
+        case KM.lookup "login" obj of
+          Just (String login) -> pure (Just login)
+          _ -> pure Nothing
+      _ -> pure Nothing
+
+unlinkGitHubUsernameHandler ::
+  AuthResult AuthenticatedUser ->
+  AppM NoContent
+unlinkGitHubUsernameHandler (Authenticated user) = do
+  let uid = auUserId user
+  runDB $ unlinkGitHubUsername uid
+  pure NoContent
+unlinkGitHubUsernameHandler _ =
+  throwError err401 {errBody = "Authentication required"}

--- a/executables/server/Aftok/Servant/Projects.hs
+++ b/executables/server/Aftok/Servant/Projects.hs
@@ -87,6 +87,7 @@ import Aftok.Servant.App (AppM, envConfig, runDB)
 import qualified Aftok.Servant.Auctions as Auctions
 import Aftok.Servant.Auth (AuthenticatedUser (..))
 import qualified Aftok.Servant.Billing as Billing
+import qualified Aftok.Servant.GitHub as GitHub
 import Aftok.ServerConfig (ServerConfig)
 import qualified Aftok.ServerConfig as QC
 import Aftok.TimeLog
@@ -165,6 +166,7 @@ singleProjectServer payCfg authResult pid =
     :<|> projectInviteHandler authResult pid
     :<|> Auctions.projectAuctionsServer authResult pid
     :<|> Billing.projectBillablesServer payCfg authResult pid
+    :<|> GitHub.gitHubProjectServer authResult pid
 
 -- | List all projects for the authenticated user
 projectListHandler :: AuthResult AuthenticatedUser -> AppM [ProjectSummary]

--- a/executables/server/Aftok/Servant/Server.hs
+++ b/executables/server/Aftok/Servant/Server.hs
@@ -12,6 +12,11 @@ module Aftok.Servant.Server
   )
 where
 
+import Aftok.API.GitHub
+  ( GitHubOAuthCallbackAPI,
+    GitHubUserAPI,
+    GitHubWebhookAPI,
+  )
 import Aftok.API.Types ()
 import qualified Aftok.Config as AC
 import Aftok.Currency.Bitcoin (NetworkMode)
@@ -29,6 +34,11 @@ import Aftok.Servant.Billing
     protectedBillingServer,
   )
 import Aftok.Servant.Config (ConfigAPI, configServer)
+import Aftok.Servant.GitHub
+  ( gitHubOAuthCallbackHandler,
+    gitHubUserServer,
+    gitHubWebhookServer,
+  )
 import Aftok.Servant.PasswordReset
   ( PasswordResetAPI,
     PasswordResetOps,
@@ -64,6 +74,7 @@ import Control.Lens ((^.))
 import Crypto.JOSE.JWK (JWK)
 import Data.Pool (Pool)
 import Database.PostgreSQL.Simple (Connection)
+import qualified Network.HTTP.Client as HTTP
 import Servant
 import Servant.Auth.Server
   ( AuthResult (..),
@@ -82,8 +93,9 @@ mkAppEnv ::
   Pool Connection ->
   ServerConfig ->
   JWK ->
+  HTTP.Manager ->
   AppEnv
-mkAppEnv nmode pool cfg jwk =
+mkAppEnv nmode pool cfg jwk mgr =
   AppEnv
     { _envNetworkMode = nmode,
       _envDbPool = pool,
@@ -100,7 +112,8 @@ mkAppEnv nmode pool cfg jwk =
                   { xsrfExcludeGet = True -- Don't require XSRF token for GET requests
                   }
           },
-      _envJWTSettings = defaultJWTSettings jwk
+      _envJWTSettings = defaultJWTSettings jwk,
+      _envHttpManager = mgr
     }
 
 -- | Full Aftok server
@@ -125,6 +138,7 @@ type ProtectedAPI =
     :<|> ProtectedPaymentsAPI
     :<|> ProtectedUsersAPI
     :<|> ProtectedSessionAPI
+    :<|> "user" :> GitHubUserAPI
 
 -- | API server (without static files)
 apiServer ::
@@ -133,12 +147,14 @@ apiServer ::
   RegisterOps IO ->
   CaptchaConfig ->
   PasswordResetOps IO ->
-  ServerT (UsersAPI :<|> SessionAPI :<|> PasswordResetAPI :<|> ConfigAPI :<|> AftokAuth :> ProtectedAPI) AppM
+  ServerT (UsersAPI :<|> SessionAPI :<|> PasswordResetAPI :<|> ConfigAPI :<|> GitHubWebhookAPI :<|> GitHubOAuthCallbackAPI :<|> AftokAuth :> ProtectedAPI) AppM
 apiServer btcCfg payCfg regOps captchaCfg pwResetOps =
   usersServer regOps captchaCfg
     :<|> sessionServer
     :<|> passwordResetServer pwResetOps
     :<|> configServer captchaCfg
+    :<|> gitHubWebhookServer
+    :<|> gitHubOAuthCallbackHandler
     :<|> protectedServer btcCfg payCfg regOps
 
 -- | Protected server (requires authentication)
@@ -156,6 +172,7 @@ protectedServer btcCfg payCfg regOps authResult =
     :<|> protectedPaymentsServer btcCfg payCfg authResult
     :<|> protectedUsersServer regOps authResult
     :<|> protectedSessionServer authResult
+    :<|> gitHubUserServer authResult
 
 -- | Protected users server
 protectedUsersServer ::

--- a/executables/server/Aftok/ServerConfig.hs
+++ b/executables/server/Aftok/ServerConfig.hs
@@ -18,6 +18,11 @@ module Aftok.ServerConfig
     captchaSiteKey,
     captchaSecretKey,
 
+    -- * GitHub OAuth Configuration
+    GitHubOAuthConfig (..),
+    ghOAuthClientId,
+    ghOAuthClientSecret,
+
     -- * Zcash Configuration
     readZcashConfig,
 
@@ -36,6 +41,8 @@ module Aftok.ServerConfig
     staticAssetPath,
     recaptchaSecret,
     zcashConfig,
+    gitHubOAuthConfig,
+    externalPort,
   )
 where
 
@@ -65,6 +72,14 @@ data CaptchaConfig = CaptchaConfig
   }
 
 makeLenses ''CaptchaConfig
+
+-- | GitHub OAuth application credentials
+data GitHubOAuthConfig = GitHubOAuthConfig
+  { _ghOAuthClientId :: Text,
+    _ghOAuthClientSecret :: Text
+  }
+
+makeLenses ''GitHubOAuthConfig
 
 -- | Database configuration
 data DbConfig = DbConfig
@@ -112,7 +127,9 @@ data ServerConfig = ServerConfig
     _templatePath :: P.FilePath,
     _staticAssetPath :: P.FilePath,
     _recaptchaSecret :: CaptchaConfig,
-    _zcashConfig :: ZcashConfig
+    _zcashConfig :: ZcashConfig,
+    _gitHubOAuthConfig :: Maybe GitHubOAuthConfig,
+    _externalPort :: Maybe Int
   }
 
 makeLenses ''ServerConfig
@@ -151,6 +168,8 @@ readServerConfig cfg pc =
         )
     <*> (CaptchaConfig <$> C.require cfg "recaptchaSiteKey" <*> C.require cfg "recaptchaSecret")
     <*> (readZcashConfig $ C.subconfig "zcash" cfg)
+    <*> readGitHubOAuthConfig (C.subconfig "github" cfg)
+    <*> C.lookup cfg "externalPort"
 
 instance CT.Configured Network where
   convert = \case
@@ -162,3 +181,9 @@ readZcashConfig :: CT.Config -> IO ZcashConfig
 readZcashConfig cfg =
   ZcashConfig
     <$> (C.require cfg "network")
+
+readGitHubOAuthConfig :: CT.Config -> IO (Maybe GitHubOAuthConfig)
+readGitHubOAuthConfig cfg = do
+  mClientId <- C.lookup cfg "oauthClientId"
+  mClientSecret <- C.lookup cfg "oauthClientSecret"
+  pure $ GitHubOAuthConfig <$> mClientId <*> mClientSecret

--- a/executables/server/Main.hs
+++ b/executables/server/Main.hs
@@ -46,6 +46,7 @@ import Database.Schema.Migrations.Store (MapValidationError, StoreData, loadMigr
 import Filesystem.Path.CurrentOS (decodeString, encodeString)
 import qualified Filesystem.Path.CurrentOS as P
 import Lrzhs (isValidShieldedAddress)
+import Network.HTTP.Client.TLS (newTlsManager)
 import Network.Mail.Mime (Mail, plainPart)
 import qualified Network.Mail.Mime as Mime
 import qualified Network.Mail.SMTP as SMTP
@@ -156,8 +157,11 @@ main = do
       pwResetOps = passwordResetOps cfg
       staticDir = encodeString $ cfg ^. staticAssetPath
 
+  -- Create TLS-capable HTTP manager for outbound API calls
+  httpManager <- newTlsManager
+
   -- Create application environment
-  let env = mkAppEnv nmode pool cfg jwk
+  let env = mkAppEnv nmode pool cfg jwk httpManager
 
   -- Create request logger (Apache format - doesn't log request bodies)
   requestLogger <-

--- a/flake.nix
+++ b/flake.nix
@@ -123,6 +123,10 @@
           ];
           buildInputs = [
             lrzhs.packages.${system}.lrzhs_ffi
+            pkgs.openssl
+            pkgs.postgresql
+            pkgs.zlib
+            pkgs.zstd
           ];
           withHoogle = true;
         };

--- a/migrations/2026-02-08_12-00-00_users-github-username.txt
+++ b/migrations/2026-02-08_12-00-00_users-github-username.txt
@@ -1,0 +1,10 @@
+Description: Add github_username column to users table for GitHub account linking
+Created: 2026-02-08 12:00:00 UTC
+Depends: 2026-02-07_00-00-00_address-change-events
+Apply: |
+  ALTER TABLE users ADD COLUMN github_username text UNIQUE;
+  CREATE INDEX idx_users_github_username ON users(github_username) WHERE github_username IS NOT NULL;
+
+Revert: |
+  DROP INDEX idx_users_github_username;
+  ALTER TABLE users DROP COLUMN github_username;

--- a/migrations/2026-02-08_12-00-01_github-repo-links.txt
+++ b/migrations/2026-02-08_12-00-01_github-repo-links.txt
@@ -1,0 +1,19 @@
+Description: Add github_repo_links table to link GitHub repositories to projects
+Created: 2026-02-08 12:00:01 UTC
+Depends: 2026-02-08_12-00-00_users-github-username
+Apply: |
+  CREATE TABLE github_repo_links (
+    id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    project_id uuid NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    github_owner text NOT NULL,
+    github_repo text NOT NULL,
+    webhook_secret text NOT NULL,
+    created_by uuid NOT NULL REFERENCES users(id),
+    created_at timestamp with time zone NOT NULL DEFAULT now(),
+    UNIQUE (github_owner, github_repo)
+  );
+
+  CREATE INDEX idx_github_repo_links_project_id ON github_repo_links(project_id);
+
+Revert: |
+  DROP TABLE github_repo_links;

--- a/migrations/2026-02-08_12-00-02_github-webhook-events.txt
+++ b/migrations/2026-02-08_12-00-02_github-webhook-events.txt
@@ -1,0 +1,30 @@
+Description: Add github_webhook_events table for audit logging of webhook processing
+Created: 2026-02-08 12:00:02 UTC
+Depends: 2026-02-08_12-00-01_github-repo-links
+Apply: |
+  CREATE TYPE github_event_status AS ENUM ('processed', 'skipped', 'error');
+
+  CREATE TABLE github_webhook_events (
+    id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    repo_link_id uuid NOT NULL REFERENCES github_repo_links(id) ON DELETE CASCADE,
+    github_delivery_id text NOT NULL UNIQUE,
+    event_type text NOT NULL,
+    pr_number integer,
+    pr_author_email text,
+    pr_author_github_login text,
+    time_spent_parsed interval,
+    status github_event_status NOT NULL,
+    error_message text,
+    work_event_id uuid REFERENCES work_events(id),
+    user_id uuid REFERENCES users(id),
+    user_created boolean NOT NULL DEFAULT false,
+    received_at timestamp with time zone NOT NULL DEFAULT now(),
+    processed_at timestamp with time zone
+  );
+
+  CREATE INDEX idx_github_webhook_events_repo_link_id ON github_webhook_events(repo_link_id);
+  CREATE INDEX idx_github_webhook_events_delivery_id ON github_webhook_events(github_delivery_id);
+
+Revert: |
+  DROP TABLE github_webhook_events;
+  DROP TYPE github_event_status;

--- a/migrations/2026-02-08_12-00-03_github-fixes.txt
+++ b/migrations/2026-02-08_12-00-03_github-fixes.txt
@@ -1,0 +1,48 @@
+Description: Apply review fixes to GitHub PR tracking schema (lowercase usernames, drop unused columns/indexes, change time_spent column type, add processing status)
+Created: 2026-02-08 12:00:03 UTC
+Depends: 2026-02-08_12-00-02_github-webhook-events
+Apply: |
+  -- 1. Normalize existing github_username values to lowercase. GitHub
+  --    treats logins case-insensitively; storing the canonical lowercase
+  --    form lets us avoid CITEXT or LOWER() comparisons at every lookup.
+  UPDATE users SET github_username = lower(github_username)
+    WHERE github_username IS NOT NULL;
+
+  -- 2. Drop the redundant explicit index on github_delivery_id; the UNIQUE
+  --    constraint already creates one.
+  DROP INDEX IF EXISTS idx_github_webhook_events_delivery_id;
+
+  -- 3. Drop the unused pr_author_email column. Nothing populates it; the
+  --    GitHub webhook payload only exposes the author's login, not their
+  --    email, so this column was always NULL.
+  ALTER TABLE github_webhook_events DROP COLUMN pr_author_email;
+
+  -- 4. Replace the interval-typed time_spent_parsed with a bigint count
+  --    of seconds. postgresql-simple has no built-in Int64 -> interval
+  --    conversion, so the previous column type was effectively unusable
+  --    via the Haskell client. A bigint of seconds round-trips trivially.
+  ALTER TABLE github_webhook_events DROP COLUMN time_spent_parsed;
+  ALTER TABLE github_webhook_events ADD COLUMN time_spent_parsed bigint;
+
+  -- 5. Add a 'processing' state to github_event_status. We insert a claim
+  --    row in this state at the start of webhook processing (via
+  --    ON CONFLICT DO NOTHING on github_delivery_id) to guarantee that
+  --    two concurrent deliveries of the same id cannot both create work
+  --    events. The claim row is updated to a terminal state when
+  --    processing finishes.
+  ALTER TYPE github_event_status ADD VALUE IF NOT EXISTS 'processing' BEFORE 'processed';
+
+  -- TODO: webhook_secret in github_repo_links is currently stored in
+  -- plaintext. Defense-in-depth encryption at rest would require
+  -- introducing a server master key and a wrapping scheme; leaving as a
+  -- follow-up.
+
+Revert: |
+  -- Note: removing an enum value isn't directly supported in PostgreSQL;
+  -- a true revert would need to rebuild the enum. We leave 'processing'
+  -- in place on revert.
+  ALTER TABLE github_webhook_events DROP COLUMN time_spent_parsed;
+  ALTER TABLE github_webhook_events ADD COLUMN time_spent_parsed interval;
+  ALTER TABLE github_webhook_events ADD COLUMN pr_author_email text;
+  CREATE INDEX idx_github_webhook_events_delivery_id
+    ON github_webhook_events(github_delivery_id);


### PR DESCRIPTION
When a PR with "Time Spent: <duration>" in its description is merged, the system automatically credits work time to the PR author. Supports duration formats like "2h30m", "2 hours", "2.5h", "150m".

Key features:
- Webhook endpoint with HMAC-SHA256 signature verification
- Links GitHub repos to Aftok projects with per-repo secrets
- Resolves users by linked GitHub username
- Creates provisional users for unknown authors when merger is a project member
- Audit logging of all webhook events for debugging/idempotency

API endpoints:
- POST /api/webhooks/github (public, signature-verified)
- GET/POST/DELETE /api/projects/:id/github/repos (manage repo links)
- GET/PUT/DELETE /api/user/github (link/unlink GitHub username)

Rebased onto autodocodec branch with:
- HasCodec instances for all request/response types
- ToSchema instances for OpenAPI spec generation
- Three-package split (core/api/executables)